### PR TITLE
Update ESLint configuration with oxlint plugin

### DIFF
--- a/.prettierrc.json
+++ b/.prettierrc.json
@@ -1,0 +1,9 @@
+{
+  "tabWidth": 2,
+  "useTabs": false,
+  "jsxSingleQuote": false,
+  "singleQuote": true,
+  "printWidth": 150,
+  "plugins": ["@prettier/plugin-oxc"],
+  "parser": "oxc-ts"
+}

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -4,5 +4,6 @@
     "ms-azuretools.azure-dev",
     "azurite.azurite",
     "dbaeumer.vscode-eslint",
+    "oxc.oxc-vscode",
   ]
 }

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -1,5 +1,6 @@
 import eslint from '@eslint/js';
 import tseslint from 'typescript-eslint';
+import oxlint from 'eslint-plugin-oxlint';
 
 export default tseslint.config(
   {
@@ -27,5 +28,7 @@ export default tseslint.config(
       },
     },
     rules: {}
-  }
+  },
+  ...oxlint.configs['flat/recommended'],
+  ...oxlint.configs['flat/typescript'],
 );

--- a/package-lock.json
+++ b/package-lock.json
@@ -2938,6 +2938,118 @@
         "node": ">=14"
       }
     },
+    "node_modules/@oxlint/darwin-arm64": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/darwin-arm64/-/darwin-arm64-1.1.0.tgz",
+      "integrity": "sha512-sSnR3SOxIU/QfaqXrcQ0UVUkzJO0bcInQ7dMhHa102gVAgWjp1fBeMVCM0adEY0UNmEXrRkgD/rQtQgn9YAU+w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@oxlint/darwin-x64": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/darwin-x64/-/darwin-x64-1.1.0.tgz",
+      "integrity": "sha512-Jvd3fHnzY2OYbmsg9NSGPoBkGViDGHSFnBKyJQ9LOIw7lxAyQBG2Quxc3GYPFR/f9OYho9C3p4+dIaAJfKhnsw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@oxlint/linux-arm64-gnu": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/linux-arm64-gnu/-/linux-arm64-gnu-1.1.0.tgz",
+      "integrity": "sha512-MgW4iskOdXuoR+wDXIJUfbdnTg2eo2FnQRaD6ZqhnDTDa7LnV+06rp/Cg3aGj2X9jSEcKDv/bMbYQuot7WRs6Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@oxlint/linux-arm64-musl": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/linux-arm64-musl/-/linux-arm64-musl-1.1.0.tgz",
+      "integrity": "sha512-a+pkEKmDRdrW+y0gtZ/m68ElVW2VZgATGbMxDgDYFpdiMx9Y0pUPwTMZ2EX/17Aslop4c1BiDSFDK7aEBxKR2g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@oxlint/linux-x64-gnu": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/linux-x64-gnu/-/linux-x64-gnu-1.1.0.tgz",
+      "integrity": "sha512-wNBsXCKVZMvUTcFitrV1wTsdhUAv8l+XQxHxciZ2SO6dpNnWEb2YCxSAIOXeyzBLdO4pIODYcSy38CvGue7TwA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@oxlint/linux-x64-musl": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/linux-x64-musl/-/linux-x64-musl-1.1.0.tgz",
+      "integrity": "sha512-pZD0lt6A5j2Wp70fgIYk4GoPfKTZ8mHWamWIpKFT7aSkFkiOi6nhLWDFvMEIHWRTK3LgkWUNcnWPp4brvin4wQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@oxlint/win32-arm64": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/win32-arm64/-/win32-arm64-1.1.0.tgz",
+      "integrity": "sha512-rT6uXQvE80+B+L04HJf30uF26426FPI9i9DAY2AxBUhrpNwhqkDEhQdd9ilFWVC7SSbpHgAs50lo+ImSAAkHPQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@oxlint/win32-x64": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/win32-x64/-/win32-x64-1.1.0.tgz",
+      "integrity": "sha512-x6r5yvM3wEty93Bx0NuNK+kutUyS/K55itkUrxdExoK6GcmVDboGGuhju9HyU2cM/IWLEWO8RHcXSyaxr9GR5g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
     "node_modules/@protobufjs/aspromise": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/@protobufjs/aspromise/-/aspromise-1.1.2.tgz",
@@ -5179,6 +5291,16 @@
         }
       }
     },
+    "node_modules/eslint-plugin-oxlint": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-oxlint/-/eslint-plugin-oxlint-1.1.0.tgz",
+      "integrity": "sha512-spDWxcsAfoUDjSwxPrP2gfuOJ2Hrv8faqQ5Vkm90lURp4no5aWJQ09xRKmZroIPTuQCKYgG9nvnakdIbXGlijg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "jsonc-parser": "^3.3.1"
+      }
+    },
     "node_modules/eslint-scope": {
       "version": "8.4.0",
       "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-8.4.0.tgz",
@@ -7030,6 +7152,13 @@
         "node": ">=6"
       }
     },
+    "node_modules/jsonc-parser": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/jsonc-parser/-/jsonc-parser-3.3.1.tgz",
+      "integrity": "sha512-HUgH65KyejrUFPvHFPbqOY0rsFip3Bo5wb4ngvdi1EpCYWUQDC5V+Y7mZws+DLkr4M//zQJoanu1SP+87Dv1oQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/jsonwebtoken": {
       "version": "9.0.2",
       "resolved": "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-9.0.2.tgz",
@@ -7716,6 +7845,33 @@
       },
       "engines": {
         "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/oxlint": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/oxlint/-/oxlint-1.1.0.tgz",
+      "integrity": "sha512-OVNpaoaQCUHHhCv5sYMPJ7Ts5k7ziw0QteH1gBSwF3elf/8GAew2Uh/0S7HsU1iGtjhlFy80+A8nwIb3Tq6m1w==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "oxc_language_server": "bin/oxc_language_server",
+        "oxlint": "bin/oxlint"
+      },
+      "engines": {
+        "node": ">=8.*"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/Boshen"
+      },
+      "optionalDependencies": {
+        "@oxlint/darwin-arm64": "1.1.0",
+        "@oxlint/darwin-x64": "1.1.0",
+        "@oxlint/linux-arm64-gnu": "1.1.0",
+        "@oxlint/linux-arm64-musl": "1.1.0",
+        "@oxlint/linux-x64-gnu": "1.1.0",
+        "@oxlint/linux-x64-musl": "1.1.0",
+        "@oxlint/win32-arm64": "1.1.0",
+        "@oxlint/win32-x64": "1.1.0"
       }
     },
     "node_modules/p-limit": {
@@ -9650,6 +9806,8 @@
       "devDependencies": {
         "@eslint/js": "^9.29.0",
         "eslint": "^9.29.0",
+        "eslint-plugin-oxlint": "^1.1.0",
+        "oxlint": "^1.1.0",
         "rimraf": "^6.0.1",
         "typescript": "^5.8.3",
         "typescript-eslint": "^8.34.0"

--- a/package-lock.json
+++ b/package-lock.json
@@ -24,7 +24,9 @@
         "packages/api"
       ],
       "devDependencies": {
+        "@prettier/plugin-oxc": "^0.0.4",
         "concurrently": "^9.1.2",
+        "prettier": "^3.6.1",
         "rimraf": "^6.0.1",
         "typescript": "^5.8.3"
       }
@@ -560,33 +562,33 @@
       }
     },
     "node_modules/@azure/msal-browser": {
-      "version": "4.13.1",
-      "resolved": "https://registry.npmjs.org/@azure/msal-browser/-/msal-browser-4.13.1.tgz",
-      "integrity": "sha512-oTp2zhVljB2CRp87swOTsBcqLDrvZq9In+yDMBzuuMN4z2wrIU6ITHBZlLfs+FaAVmM1zY3k7ITekXaJ2bsDKA==",
+      "version": "4.13.2",
+      "resolved": "https://registry.npmjs.org/@azure/msal-browser/-/msal-browser-4.13.2.tgz",
+      "integrity": "sha512-lS75bF6FYZRwsacKLXc8UYu/jb+gOB7dtZq5938chCvV/zKTFDnzuXxCXhsSUh0p8s/P8ztgbfdueD9lFARQlQ==",
       "license": "MIT",
       "dependencies": {
-        "@azure/msal-common": "15.7.0"
+        "@azure/msal-common": "15.7.1"
       },
       "engines": {
         "node": ">=0.8.0"
       }
     },
     "node_modules/@azure/msal-common": {
-      "version": "15.7.0",
-      "resolved": "https://registry.npmjs.org/@azure/msal-common/-/msal-common-15.7.0.tgz",
-      "integrity": "sha512-m9M5hoFoxhe/HlXNVa4qBHekrX60CVPkWzsjhKQGuzw/OPOmurosKRPDIMn8fug/E1hHI5v33DvT1LVJfItjcg==",
+      "version": "15.7.1",
+      "resolved": "https://registry.npmjs.org/@azure/msal-common/-/msal-common-15.7.1.tgz",
+      "integrity": "sha512-a0eowoYfRfKZEjbiCoA5bPT3IlWRAdGSvi63OU23Hv+X6EI8gbvXCoeqokUceFMoT9NfRUWTJSx5FiuzruqT8g==",
       "license": "MIT",
       "engines": {
         "node": ">=0.8.0"
       }
     },
     "node_modules/@azure/msal-node": {
-      "version": "3.6.0",
-      "resolved": "https://registry.npmjs.org/@azure/msal-node/-/msal-node-3.6.0.tgz",
-      "integrity": "sha512-MRZ38Ou6l9LiRkz/968mG0czfIvD1PxMZ/3Jyz5k00ZMnhNOwv+DIliEcy//laoWDobAAq+/cz97xefCcHPgjg==",
+      "version": "3.6.1",
+      "resolved": "https://registry.npmjs.org/@azure/msal-node/-/msal-node-3.6.1.tgz",
+      "integrity": "sha512-ctcVz4xS+st5KxOlQqgpvA+uDFAa59CvkmumnuhlD2XmNczloKBdCiMQG7/TigSlaeHe01qoOlDjz3TyUAmKUg==",
       "license": "MIT",
       "dependencies": {
-        "@azure/msal-common": "15.7.0",
+        "@azure/msal-common": "15.7.1",
         "jsonwebtoken": "^9.0.0",
         "uuid": "^8.3.0"
       },
@@ -1145,6 +1147,40 @@
       "resolved": "packages/cellix-event-bus-seedwork-node",
       "link": true
     },
+    "node_modules/@emnapi/core": {
+      "version": "1.4.3",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.4.3.tgz",
+      "integrity": "sha512-4m62DuCE07lw01soJwPiBGC0nAww0Q+RY70VZ+n49yDIO13yyinhbWCeNnaob0lakDtWQzSdtNWzJeOJt2ma+g==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.0.2",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/runtime": {
+      "version": "1.4.3",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.4.3.tgz",
+      "integrity": "sha512-pBPWdu6MLKROBX05wSNKcNb++m5Er+KQ9QkB+WVM+pW2Kx9hoSrVTnu3BdkI5eBLZoKu/J6mW/B6i6bJB2ytXQ==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/wasi-threads": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.0.2.tgz",
+      "integrity": "sha512-5n3nTJblwRi8LlXkJ9eBzu+kZR8Yxcc7ubakyQTFzPMtIhFpUBRbsnc2Dv88IZDIbCDlBiWrknhB4Lsz7mg6BA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
     "node_modules/@eslint-community/eslint-utils": {
       "version": "4.7.0",
       "resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.7.0.tgz",
@@ -1299,13 +1335,13 @@
       }
     },
     "node_modules/@eslint/plugin-kit": {
-      "version": "0.3.2",
-      "resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.3.2.tgz",
-      "integrity": "sha512-4SaFZCNfJqvk/kenHpI8xvN42DMaoycy4PzKc5otHxRswww1kAt82OlBuwRVLofCACCTZEcla2Ydxv8scMXaTg==",
+      "version": "0.3.3",
+      "resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.3.3.tgz",
+      "integrity": "sha512-1+WqvgNMhmlAambTvT3KPtCl/Ibr68VldY2XY40SL1CE0ZXiakFR/cbTspaF5HsnpDMvcYYoJHfl4980NBjGag==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@eslint/core": "^0.15.0",
+        "@eslint/core": "^0.15.1",
         "levn": "^0.4.1"
       },
       "engines": {
@@ -1313,9 +1349,9 @@
       }
     },
     "node_modules/@eslint/plugin-kit/node_modules/@eslint/core": {
-      "version": "0.15.0",
-      "resolved": "https://registry.npmjs.org/@eslint/core/-/core-0.15.0.tgz",
-      "integrity": "sha512-b7ePw78tEWWkpgZCDYkbqDOP8dmM6qe+AOC6iuJqlq1R/0ahMAeH3qynpnqKFGkMltrp44ohV4ubGyvLX28tzw==",
+      "version": "0.15.1",
+      "resolved": "https://registry.npmjs.org/@eslint/core/-/core-0.15.1.tgz",
+      "integrity": "sha512-bkOp+iumZCCbt1K1CmWf0R9pM5yKpDv+ZXtvSyQpudrI9kuFLp+bM2WOPXImuD/ceQuaa8f5pj93Y7zyECIGNA==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -2091,6 +2127,19 @@
       "license": "MIT",
       "dependencies": {
         "sparse-bitfield": "^3.0.3"
+      }
+    },
+    "node_modules/@napi-rs/wasm-runtime": {
+      "version": "0.2.11",
+      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-0.2.11.tgz",
+      "integrity": "sha512-9DPkXtvHydrcOsopiYpUgPHpmj0HWZKMUnL2dZqpvC42lsratuBG06V5ipyno0fUek5VlFsNQ+AcFATSrJXgMA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/core": "^1.4.3",
+        "@emnapi/runtime": "^1.4.3",
+        "@tybys/wasm-util": "^0.9.0"
       }
     },
     "node_modules/@nodelib/fs.scandir": {
@@ -2938,10 +2987,275 @@
         "node": ">=14"
       }
     },
+    "node_modules/@oxc-parser/binding-android-arm64": {
+      "version": "0.74.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-android-arm64/-/binding-android-arm64-0.74.0.tgz",
+      "integrity": "sha512-lgq8TJq22eyfojfa2jBFy2m66ckAo7iNRYDdyn9reXYA3I6Wx7tgGWVx1JAp1lO+aUiqdqP/uPlDaETL9tqRcg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@oxc-parser/binding-darwin-arm64": {
+      "version": "0.74.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-darwin-arm64/-/binding-darwin-arm64-0.74.0.tgz",
+      "integrity": "sha512-xbY/io/hkARggbpYEMFX6CwFzb7f4iS6WuBoBeZtdqRWfIEi7sm/uYWXfyVeB8uqOATvJ07WRFC2upI8PSI83g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@oxc-parser/binding-darwin-x64": {
+      "version": "0.74.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-darwin-x64/-/binding-darwin-x64-0.74.0.tgz",
+      "integrity": "sha512-FIj2gAGtFaW0Zk+TnGyenMUoRu1ju+kJ/h71D77xc1owOItbFZFGa+4WSVck1H8rTtceeJlK+kux+vCjGFCl9Q==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@oxc-parser/binding-freebsd-x64": {
+      "version": "0.74.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-freebsd-x64/-/binding-freebsd-x64-0.74.0.tgz",
+      "integrity": "sha512-W1I+g5TJg0TRRMHgEWNWsTIfe782V3QuaPgZxnfPNmDMywYdtlzllzclBgaDq6qzvZCCQc/UhvNb37KWTCTj8A==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@oxc-parser/binding-linux-arm-gnueabihf": {
+      "version": "0.74.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-0.74.0.tgz",
+      "integrity": "sha512-gxqkyRGApeVI8dgvJ19SYe59XASW3uVxF1YUgkE7peW/XIg5QRAOVTFKyTjI9acYuK1MF6OJHqx30cmxmZLtiQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@oxc-parser/binding-linux-arm-musleabihf": {
+      "version": "0.74.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-arm-musleabihf/-/binding-linux-arm-musleabihf-0.74.0.tgz",
+      "integrity": "sha512-jpnAUP4Fa93VdPPDzxxBguJmldj/Gpz7wTXKFzpAueqBMfZsy9KNC+0qT2uZ9HGUDMzNuKw0Se3bPCpL/gfD2Q==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@oxc-parser/binding-linux-arm64-gnu": {
+      "version": "0.74.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-0.74.0.tgz",
+      "integrity": "sha512-fcWyM7BNfCkHqIf3kll8fJctbR/PseL4RnS2isD9Y3FFBhp4efGAzhDaxIUK5GK7kIcFh1P+puIRig8WJ6IMVQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@oxc-parser/binding-linux-arm64-musl": {
+      "version": "0.74.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-arm64-musl/-/binding-linux-arm64-musl-0.74.0.tgz",
+      "integrity": "sha512-AMY30z/C77HgiRRJX7YtVUaelKq1ex0aaj28XoJu4SCezdS8i0IftUNTtGS1UzGjGZB8zQz5SFwVy4dRu4GLwg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@oxc-parser/binding-linux-riscv64-gnu": {
+      "version": "0.74.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-riscv64-gnu/-/binding-linux-riscv64-gnu-0.74.0.tgz",
+      "integrity": "sha512-/RZAP24TgZo4vV/01TBlzRqs0R7E6xvatww4LnmZEBBulQBU/SkypDywfriFqWuFoa61WFXPV7sLcTjJGjim/w==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@oxc-parser/binding-linux-s390x-gnu": {
+      "version": "0.74.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-0.74.0.tgz",
+      "integrity": "sha512-620J1beNAlGSPBD+Msb3ptvrwxu04B8iULCH03zlf0JSLy/5sqlD6qBs0XUVkUJv1vbakUw1gfVnUQqv0UTuEg==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@oxc-parser/binding-linux-x64-gnu": {
+      "version": "0.74.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-x64-gnu/-/binding-linux-x64-gnu-0.74.0.tgz",
+      "integrity": "sha512-WBFgQmGtFnPNzHyLKbC1wkYGaRIBxXGofO0+hz1xrrkPgbxbJS1Ukva1EB8sPaVBBQ52Bdc2GjLSp721NWRvww==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@oxc-parser/binding-linux-x64-musl": {
+      "version": "0.74.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-x64-musl/-/binding-linux-x64-musl-0.74.0.tgz",
+      "integrity": "sha512-y4mapxi0RGqlp3t6Sm+knJlAEqdKDYrEue2LlXOka/F2i4sRN0XhEMPiSOB3ppHmvK4I2zY2XBYTsX1Fel0fAg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@oxc-parser/binding-wasm32-wasi": {
+      "version": "0.74.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-wasm32-wasi/-/binding-wasm32-wasi-0.74.0.tgz",
+      "integrity": "sha512-yDS9bRDh5ymobiS2xBmjlrGdUuU61IZoJBaJC5fELdYT5LJNBXlbr3Yc6m2PWfRJwkH6Aq5fRvxAZ4wCbkGa8w==",
+      "cpu": [
+        "wasm32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@napi-rs/wasm-runtime": "^0.2.11"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@oxc-parser/binding-win32-arm64-msvc": {
+      "version": "0.74.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-0.74.0.tgz",
+      "integrity": "sha512-XFWY52Rfb4N5wEbMCTSBMxRkDLGbAI9CBSL24BIDywwDJMl31gHEVlmHdCDRoXAmanCI6gwbXYTrWe0HvXJ7Aw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@oxc-parser/binding-win32-x64-msvc": {
+      "version": "0.74.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-win32-x64-msvc/-/binding-win32-x64-msvc-0.74.0.tgz",
+      "integrity": "sha512-1D3x6iU2apLyfTQHygbdaNbX3nZaHu4yaXpD7ilYpoLo7f0MX0tUuoDrqJyJrVGqvyXgc0uz4yXz9tH9ZZhvvg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@oxc-project/types": {
+      "version": "0.74.0",
+      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.74.0.tgz",
+      "integrity": "sha512-KOw/RZrVlHGhCXh1RufBFF7Nuo7HdY5w1lRJukM/igIl6x9qtz8QycDvZdzb4qnHO7znrPyo2sJrFJK2eKHgfQ==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/Boshen"
+      }
+    },
     "node_modules/@oxlint/darwin-arm64": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@oxlint/darwin-arm64/-/darwin-arm64-1.1.0.tgz",
-      "integrity": "sha512-sSnR3SOxIU/QfaqXrcQ0UVUkzJO0bcInQ7dMhHa102gVAgWjp1fBeMVCM0adEY0UNmEXrRkgD/rQtQgn9YAU+w==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/darwin-arm64/-/darwin-arm64-1.3.0.tgz",
+      "integrity": "sha512-TcCaETXYfiEfS+u/gZNND4WwEEtnJJjqg8BIC56WiCQDduYTvmmbQ0vxtqdNXlFzlvmRpZCSs7qaqXNy8/8FLA==",
       "cpu": [
         "arm64"
       ],
@@ -2953,9 +3267,9 @@
       ]
     },
     "node_modules/@oxlint/darwin-x64": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@oxlint/darwin-x64/-/darwin-x64-1.1.0.tgz",
-      "integrity": "sha512-Jvd3fHnzY2OYbmsg9NSGPoBkGViDGHSFnBKyJQ9LOIw7lxAyQBG2Quxc3GYPFR/f9OYho9C3p4+dIaAJfKhnsw==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/darwin-x64/-/darwin-x64-1.3.0.tgz",
+      "integrity": "sha512-REgq9s1ZWuh++Vi+mUPNddLTp/D+iu+T8nLd3QM1dzQoBD/SZ7wRX3Mdv8QGT/m8dknmDBQuKAP6T47ox9HRSA==",
       "cpu": [
         "x64"
       ],
@@ -2967,9 +3281,9 @@
       ]
     },
     "node_modules/@oxlint/linux-arm64-gnu": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@oxlint/linux-arm64-gnu/-/linux-arm64-gnu-1.1.0.tgz",
-      "integrity": "sha512-MgW4iskOdXuoR+wDXIJUfbdnTg2eo2FnQRaD6ZqhnDTDa7LnV+06rp/Cg3aGj2X9jSEcKDv/bMbYQuot7WRs6Q==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/linux-arm64-gnu/-/linux-arm64-gnu-1.3.0.tgz",
+      "integrity": "sha512-QAS8AWKDcDeUe8mJaw/pF2D9+js8FbFTo75AiekZKNm9V6QAAiCkyvesmILD8RrStw9aV2D/apOD71vsfcDoGA==",
       "cpu": [
         "arm64"
       ],
@@ -2981,9 +3295,9 @@
       ]
     },
     "node_modules/@oxlint/linux-arm64-musl": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@oxlint/linux-arm64-musl/-/linux-arm64-musl-1.1.0.tgz",
-      "integrity": "sha512-a+pkEKmDRdrW+y0gtZ/m68ElVW2VZgATGbMxDgDYFpdiMx9Y0pUPwTMZ2EX/17Aslop4c1BiDSFDK7aEBxKR2g==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/linux-arm64-musl/-/linux-arm64-musl-1.3.0.tgz",
+      "integrity": "sha512-rAbz0KFkk5GPdERoFO4ZUZmVkECnHXjRG0O2MeT5zY7ddlyZUjEk1cWjw+HCtWVdKkqhZJeNFMuEiRLkpzBIIw==",
       "cpu": [
         "arm64"
       ],
@@ -2995,9 +3309,9 @@
       ]
     },
     "node_modules/@oxlint/linux-x64-gnu": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@oxlint/linux-x64-gnu/-/linux-x64-gnu-1.1.0.tgz",
-      "integrity": "sha512-wNBsXCKVZMvUTcFitrV1wTsdhUAv8l+XQxHxciZ2SO6dpNnWEb2YCxSAIOXeyzBLdO4pIODYcSy38CvGue7TwA==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/linux-x64-gnu/-/linux-x64-gnu-1.3.0.tgz",
+      "integrity": "sha512-6uLO1WsJwCtVNGHtjXwg2TRvxQYttYJKMjSdv6RUXGWY1AI+/+yHzvu+phU/F40uNC7CFhFnqWDuPaSZ49hdAQ==",
       "cpu": [
         "x64"
       ],
@@ -3009,9 +3323,9 @@
       ]
     },
     "node_modules/@oxlint/linux-x64-musl": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@oxlint/linux-x64-musl/-/linux-x64-musl-1.1.0.tgz",
-      "integrity": "sha512-pZD0lt6A5j2Wp70fgIYk4GoPfKTZ8mHWamWIpKFT7aSkFkiOi6nhLWDFvMEIHWRTK3LgkWUNcnWPp4brvin4wQ==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/linux-x64-musl/-/linux-x64-musl-1.3.0.tgz",
+      "integrity": "sha512-+vrmJUHgtJmgIo+L9eTP04NI/OQNCOZtQo6I49qGWc9cpr+0MnIh9KMcyAOxmzVTF5g+CF1I/1bUz4pk4I3LDw==",
       "cpu": [
         "x64"
       ],
@@ -3023,9 +3337,9 @@
       ]
     },
     "node_modules/@oxlint/win32-arm64": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@oxlint/win32-arm64/-/win32-arm64-1.1.0.tgz",
-      "integrity": "sha512-rT6uXQvE80+B+L04HJf30uF26426FPI9i9DAY2AxBUhrpNwhqkDEhQdd9ilFWVC7SSbpHgAs50lo+ImSAAkHPQ==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/win32-arm64/-/win32-arm64-1.3.0.tgz",
+      "integrity": "sha512-k+ETUVl+O3b8Rcd2PP5V3LqQ2QoN/TOX2f19XXHZEynbVLY3twLYPb3hLdXqoo7CKRq3RJdTfn1upHH48/qrZQ==",
       "cpu": [
         "arm64"
       ],
@@ -3037,9 +3351,9 @@
       ]
     },
     "node_modules/@oxlint/win32-x64": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@oxlint/win32-x64/-/win32-x64-1.1.0.tgz",
-      "integrity": "sha512-x6r5yvM3wEty93Bx0NuNK+kutUyS/K55itkUrxdExoK6GcmVDboGGuhju9HyU2cM/IWLEWO8RHcXSyaxr9GR5g==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/win32-x64/-/win32-x64-1.3.0.tgz",
+      "integrity": "sha512-nWSgK0fT02TQ/BiAUCd13BaobtHySkCDcQaL+NOmhgeb0tNWjtYiktuluahaIqFcYJPWczVlbs8DU/Eqo8vsug==",
       "cpu": [
         "x64"
       ],
@@ -3049,6 +3363,22 @@
       "os": [
         "win32"
       ]
+    },
+    "node_modules/@prettier/plugin-oxc": {
+      "version": "0.0.4",
+      "resolved": "https://registry.npmjs.org/@prettier/plugin-oxc/-/plugin-oxc-0.0.4.tgz",
+      "integrity": "sha512-UGXe+g/rSRbglL0FOJiar+a+nUrst7KaFmsg05wYbKiInGWP6eAj/f8A2Uobgo5KxEtb2X10zeflNH6RK2xeIQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "oxc-parser": "0.74.0"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/prettier/prettier?sponsor=1"
+      }
     },
     "node_modules/@protobufjs/aspromise": {
       "version": "1.1.2",
@@ -3139,6 +3469,17 @@
       "license": "BSD-3-Clause",
       "dependencies": {
         "@sinonjs/commons": "^3.0.0"
+      }
+    },
+    "node_modules/@tybys/wasm-util": {
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.9.0.tgz",
+      "integrity": "sha512-6+7nlbMVX/PVDCwaIQ8nTOPveOcFLSt8GcXdx8hD0bt39uWxYT88uXzqTd4fTvqta7oeUJqudepapKNt2DYJFw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
       }
     },
     "node_modules/@types/babel__core": {
@@ -3319,9 +3660,9 @@
       }
     },
     "node_modules/@types/node": {
-      "version": "24.0.3",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.0.3.tgz",
-      "integrity": "sha512-R4I/kzCYAdRLzfiCabn9hxWfbuHS573x+r0dJMkkzThEa7pbrcDWK+9zu3e7aBOouf+rQAciqPFMnxwr0aWgKg==",
+      "version": "24.0.4",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.0.4.tgz",
+      "integrity": "sha512-ulyqAkrhnuNq9pB76DRBTkcS6YsmDALy6Ua63V8OhrOBgbcYt6IOdzpw5P1+dyRIyMerzLkeYWBeOXPpA9GMAA==",
       "license": "MIT",
       "dependencies": {
         "undici-types": "~7.8.0"
@@ -3416,17 +3757,17 @@
       "license": "MIT"
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
-      "version": "8.34.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.34.1.tgz",
-      "integrity": "sha512-STXcN6ebF6li4PxwNeFnqF8/2BNDvBupf2OPx2yWNzr6mKNGF7q49VM00Pz5FaomJyqvbXpY6PhO+T9w139YEQ==",
+      "version": "8.35.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.35.0.tgz",
+      "integrity": "sha512-ijItUYaiWuce0N1SoSMrEd0b6b6lYkYt99pqCPfybd+HKVXtEvYhICfLdwp42MhiI5mp0oq7PKEL+g1cNiz/Eg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@eslint-community/regexpp": "^4.10.0",
-        "@typescript-eslint/scope-manager": "8.34.1",
-        "@typescript-eslint/type-utils": "8.34.1",
-        "@typescript-eslint/utils": "8.34.1",
-        "@typescript-eslint/visitor-keys": "8.34.1",
+        "@typescript-eslint/scope-manager": "8.35.0",
+        "@typescript-eslint/type-utils": "8.35.0",
+        "@typescript-eslint/utils": "8.35.0",
+        "@typescript-eslint/visitor-keys": "8.35.0",
         "graphemer": "^1.4.0",
         "ignore": "^7.0.0",
         "natural-compare": "^1.4.0",
@@ -3440,7 +3781,7 @@
         "url": "https://opencollective.com/typescript-eslint"
       },
       "peerDependencies": {
-        "@typescript-eslint/parser": "^8.34.1",
+        "@typescript-eslint/parser": "^8.35.0",
         "eslint": "^8.57.0 || ^9.0.0",
         "typescript": ">=4.8.4 <5.9.0"
       }
@@ -3456,16 +3797,16 @@
       }
     },
     "node_modules/@typescript-eslint/parser": {
-      "version": "8.34.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.34.1.tgz",
-      "integrity": "sha512-4O3idHxhyzjClSMJ0a29AcoK0+YwnEqzI6oz3vlRf3xw0zbzt15MzXwItOlnr5nIth6zlY2RENLsOPvhyrKAQA==",
+      "version": "8.35.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.35.0.tgz",
+      "integrity": "sha512-6sMvZePQrnZH2/cJkwRpkT7DxoAWh+g6+GFRK6bV3YQo7ogi3SX5rgF6099r5Q53Ma5qeT7LGmOmuIutF4t3lA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/scope-manager": "8.34.1",
-        "@typescript-eslint/types": "8.34.1",
-        "@typescript-eslint/typescript-estree": "8.34.1",
-        "@typescript-eslint/visitor-keys": "8.34.1",
+        "@typescript-eslint/scope-manager": "8.35.0",
+        "@typescript-eslint/types": "8.35.0",
+        "@typescript-eslint/typescript-estree": "8.35.0",
+        "@typescript-eslint/visitor-keys": "8.35.0",
         "debug": "^4.3.4"
       },
       "engines": {
@@ -3481,14 +3822,14 @@
       }
     },
     "node_modules/@typescript-eslint/project-service": {
-      "version": "8.34.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.34.1.tgz",
-      "integrity": "sha512-nuHlOmFZfuRwLJKDGQOVc0xnQrAmuq1Mj/ISou5044y1ajGNp2BNliIqp7F2LPQ5sForz8lempMFCovfeS1XoA==",
+      "version": "8.35.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.35.0.tgz",
+      "integrity": "sha512-41xatqRwWZuhUMF/aZm2fcUsOFKNcG28xqRSS6ZVr9BVJtGExosLAm5A1OxTjRMagx8nJqva+P5zNIGt8RIgbQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/tsconfig-utils": "^8.34.1",
-        "@typescript-eslint/types": "^8.34.1",
+        "@typescript-eslint/tsconfig-utils": "^8.35.0",
+        "@typescript-eslint/types": "^8.35.0",
         "debug": "^4.3.4"
       },
       "engines": {
@@ -3503,14 +3844,14 @@
       }
     },
     "node_modules/@typescript-eslint/scope-manager": {
-      "version": "8.34.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.34.1.tgz",
-      "integrity": "sha512-beu6o6QY4hJAgL1E8RaXNC071G4Kso2MGmJskCFQhRhg8VOH/FDbC8soP8NHN7e/Hdphwp8G8cE6OBzC8o41ZA==",
+      "version": "8.35.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.35.0.tgz",
+      "integrity": "sha512-+AgL5+mcoLxl1vGjwNfiWq5fLDZM1TmTPYs2UkyHfFhgERxBbqHlNjRzhThJqz+ktBqTChRYY6zwbMwy0591AA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.34.1",
-        "@typescript-eslint/visitor-keys": "8.34.1"
+        "@typescript-eslint/types": "8.35.0",
+        "@typescript-eslint/visitor-keys": "8.35.0"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -3521,9 +3862,9 @@
       }
     },
     "node_modules/@typescript-eslint/tsconfig-utils": {
-      "version": "8.34.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.34.1.tgz",
-      "integrity": "sha512-K4Sjdo4/xF9NEeA2khOb7Y5nY6NSXBnod87uniVYW9kHP+hNlDV8trUSFeynA2uxWam4gIWgWoygPrv9VMWrYg==",
+      "version": "8.35.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.35.0.tgz",
+      "integrity": "sha512-04k/7247kZzFraweuEirmvUj+W3bJLI9fX6fbo1Qm2YykuBvEhRTPl8tcxlYO8kZZW+HIXfkZNoasVb8EV4jpA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -3538,14 +3879,14 @@
       }
     },
     "node_modules/@typescript-eslint/type-utils": {
-      "version": "8.34.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.34.1.tgz",
-      "integrity": "sha512-Tv7tCCr6e5m8hP4+xFugcrwTOucB8lshffJ6zf1mF1TbU67R+ntCc6DzLNKM+s/uzDyv8gLq7tufaAhIBYeV8g==",
+      "version": "8.35.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.35.0.tgz",
+      "integrity": "sha512-ceNNttjfmSEoM9PW87bWLDEIaLAyR+E6BoYJQ5PfaDau37UGca9Nyq3lBk8Bw2ad0AKvYabz6wxc7DMTO2jnNA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/typescript-estree": "8.34.1",
-        "@typescript-eslint/utils": "8.34.1",
+        "@typescript-eslint/typescript-estree": "8.35.0",
+        "@typescript-eslint/utils": "8.35.0",
         "debug": "^4.3.4",
         "ts-api-utils": "^2.1.0"
       },
@@ -3562,9 +3903,9 @@
       }
     },
     "node_modules/@typescript-eslint/types": {
-      "version": "8.34.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.34.1.tgz",
-      "integrity": "sha512-rjLVbmE7HR18kDsjNIZQHxmv9RZwlgzavryL5Lnj2ujIRTeXlKtILHgRNmQ3j4daw7zd+mQgy+uyt6Zo6I0IGA==",
+      "version": "8.35.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.35.0.tgz",
+      "integrity": "sha512-0mYH3emanku0vHw2aRLNGqe7EXh9WHEhi7kZzscrMDf6IIRUQ5Jk4wp1QrledE/36KtdZrVfKnE32eZCf/vaVQ==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -3576,16 +3917,16 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree": {
-      "version": "8.34.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.34.1.tgz",
-      "integrity": "sha512-rjCNqqYPuMUF5ODD+hWBNmOitjBWghkGKJg6hiCHzUvXRy6rK22Jd3rwbP2Xi+R7oYVvIKhokHVhH41BxPV5mA==",
+      "version": "8.35.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.35.0.tgz",
+      "integrity": "sha512-F+BhnaBemgu1Qf8oHrxyw14wq6vbL8xwWKKMwTMwYIRmFFY/1n/9T/jpbobZL8vp7QyEUcC6xGrnAO4ua8Kp7w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/project-service": "8.34.1",
-        "@typescript-eslint/tsconfig-utils": "8.34.1",
-        "@typescript-eslint/types": "8.34.1",
-        "@typescript-eslint/visitor-keys": "8.34.1",
+        "@typescript-eslint/project-service": "8.35.0",
+        "@typescript-eslint/tsconfig-utils": "8.35.0",
+        "@typescript-eslint/types": "8.35.0",
+        "@typescript-eslint/visitor-keys": "8.35.0",
         "debug": "^4.3.4",
         "fast-glob": "^3.3.2",
         "is-glob": "^4.0.3",
@@ -3631,16 +3972,16 @@
       }
     },
     "node_modules/@typescript-eslint/utils": {
-      "version": "8.34.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.34.1.tgz",
-      "integrity": "sha512-mqOwUdZ3KjtGk7xJJnLbHxTuWVn3GO2WZZuM+Slhkun4+qthLdXx32C8xIXbO1kfCECb3jIs3eoxK3eryk7aoQ==",
+      "version": "8.35.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.35.0.tgz",
+      "integrity": "sha512-nqoMu7WWM7ki5tPgLVsmPM8CkqtoPUG6xXGeefM5t4x3XumOEKMoUZPdi+7F+/EotukN4R9OWdmDxN80fqoZeg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.7.0",
-        "@typescript-eslint/scope-manager": "8.34.1",
-        "@typescript-eslint/types": "8.34.1",
-        "@typescript-eslint/typescript-estree": "8.34.1"
+        "@typescript-eslint/scope-manager": "8.35.0",
+        "@typescript-eslint/types": "8.35.0",
+        "@typescript-eslint/typescript-estree": "8.35.0"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -3655,13 +3996,13 @@
       }
     },
     "node_modules/@typescript-eslint/visitor-keys": {
-      "version": "8.34.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.34.1.tgz",
-      "integrity": "sha512-xoh5rJ+tgsRKoXnkBPFRLZ7rjKM0AfVbC68UZ/ECXoDbfggb9RbEySN359acY1vS3qZ0jVTVWzbtfapwm5ztxw==",
+      "version": "8.35.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.35.0.tgz",
+      "integrity": "sha512-zTh2+1Y8ZpmeQaQVIc/ZZxsx8UzgKJyNg1PTvjzC7WMhPSVS8bfDX34k1SrwOf016qd5RU3az2UxUNue3IfQ5g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.34.1",
+        "@typescript-eslint/types": "8.35.0",
         "eslint-visitor-keys": "^4.2.1"
       },
       "engines": {
@@ -4449,9 +4790,9 @@
       }
     },
     "node_modules/browserslist": {
-      "version": "4.25.0",
-      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.25.0.tgz",
-      "integrity": "sha512-PJ8gYKeS5e/whHBh8xrwYK+dAvEj7JXtz6uTucnMRB8OiGTsKccFekoRrjajPBHV8oOY+2tI4uxeceSimKwMFA==",
+      "version": "4.25.1",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.25.1.tgz",
+      "integrity": "sha512-KGj0KoOMXLpSNkkEI6Z6mShmQy0bc1I+T7K9N81k4WWMrfz+6fQ6es80B/YLAeRoKvjYE1YSHHOW1qe9xIVzHw==",
       "dev": true,
       "funding": [
         {
@@ -4469,8 +4810,8 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "caniuse-lite": "^1.0.30001718",
-        "electron-to-chromium": "^1.5.160",
+        "caniuse-lite": "^1.0.30001726",
+        "electron-to-chromium": "^1.5.173",
         "node-releases": "^2.0.19",
         "update-browserslist-db": "^1.1.3"
       },
@@ -4587,9 +4928,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001723",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001723.tgz",
-      "integrity": "sha512-1R/elMjtehrFejxwmexeXAtae5UO9iSyFn6G/I806CYC/BLyyBk1EPhrKBkWhy6wM6Xnm47dSJQec+tLJ39WHw==",
+      "version": "1.0.30001726",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001726.tgz",
+      "integrity": "sha512-VQAUIUzBiZ/UnlM28fSp2CRF3ivUn1BWEvxMcVTNwpw91Py1pGbPIyIKtd+tzct9C3ouceCVdGAXxZOpZAsgdw==",
       "dev": true,
       "funding": [
         {
@@ -4797,9 +5138,9 @@
       "license": "MIT"
     },
     "node_modules/concurrently": {
-      "version": "9.1.2",
-      "resolved": "https://registry.npmjs.org/concurrently/-/concurrently-9.1.2.tgz",
-      "integrity": "sha512-H9MWcoPsYddwbOGM6difjVwVZHl63nwMEwDJG/L7VGtuaJhb12h2caPG2tVPWs7emuYix252iGfqOyrz1GczTQ==",
+      "version": "9.2.0",
+      "resolved": "https://registry.npmjs.org/concurrently/-/concurrently-9.2.0.tgz",
+      "integrity": "sha512-IsB/fiXTupmagMW4MNp2lx2cdSN2FfZq78vF90LBB+zZHArbIQZjQtzXCiXnvTxCZSvXanTqFLWBjw2UkLx1SQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -5087,9 +5428,9 @@
       "license": "MIT"
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.5.169",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.169.tgz",
-      "integrity": "sha512-q7SQx6mkLy0GTJK9K9OiWeaBMV4XQtBSdf6MJUzDB/H/5tFXfIiX38Lci1Kl6SsgiEhz1SQI1ejEOU5asWEhwQ==",
+      "version": "1.5.176",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.176.tgz",
+      "integrity": "sha512-2nDK9orkm7M9ZZkjO3PjbEd3VUulQLyg5T9O3enJdFvUg46Hzd4DUvTvAuEgbdHYXyFsiG4A5sO9IzToMH1cDg==",
       "dev": true,
       "license": "ISC"
     },
@@ -5292,9 +5633,9 @@
       }
     },
     "node_modules/eslint-plugin-oxlint": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-oxlint/-/eslint-plugin-oxlint-1.1.0.tgz",
-      "integrity": "sha512-spDWxcsAfoUDjSwxPrP2gfuOJ2Hrv8faqQ5Vkm90lURp4no5aWJQ09xRKmZroIPTuQCKYgG9nvnakdIbXGlijg==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-oxlint/-/eslint-plugin-oxlint-1.3.0.tgz",
+      "integrity": "sha512-3d21Beq7hJ8IokOCelzefBLxntKPYJjQj9CeyTHiVUo6n4Fj1GgdL1PrqzS7lP882QHD6ubur18aYIU7tdgMpQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -7847,10 +8188,43 @@
         "node": ">= 0.8.0"
       }
     },
+    "node_modules/oxc-parser": {
+      "version": "0.74.0",
+      "resolved": "https://registry.npmjs.org/oxc-parser/-/oxc-parser-0.74.0.tgz",
+      "integrity": "sha512-2tDN/ttU8WE6oFh8EzKNam7KE7ZXSG5uXmvX85iNzxdJfMssDWcj3gpYzZi1E04XuE7m3v1dVWl/8BE886vPGw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@oxc-project/types": "^0.74.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/Boshen"
+      },
+      "optionalDependencies": {
+        "@oxc-parser/binding-android-arm64": "0.74.0",
+        "@oxc-parser/binding-darwin-arm64": "0.74.0",
+        "@oxc-parser/binding-darwin-x64": "0.74.0",
+        "@oxc-parser/binding-freebsd-x64": "0.74.0",
+        "@oxc-parser/binding-linux-arm-gnueabihf": "0.74.0",
+        "@oxc-parser/binding-linux-arm-musleabihf": "0.74.0",
+        "@oxc-parser/binding-linux-arm64-gnu": "0.74.0",
+        "@oxc-parser/binding-linux-arm64-musl": "0.74.0",
+        "@oxc-parser/binding-linux-riscv64-gnu": "0.74.0",
+        "@oxc-parser/binding-linux-s390x-gnu": "0.74.0",
+        "@oxc-parser/binding-linux-x64-gnu": "0.74.0",
+        "@oxc-parser/binding-linux-x64-musl": "0.74.0",
+        "@oxc-parser/binding-wasm32-wasi": "0.74.0",
+        "@oxc-parser/binding-win32-arm64-msvc": "0.74.0",
+        "@oxc-parser/binding-win32-x64-msvc": "0.74.0"
+      }
+    },
     "node_modules/oxlint": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/oxlint/-/oxlint-1.1.0.tgz",
-      "integrity": "sha512-OVNpaoaQCUHHhCv5sYMPJ7Ts5k7ziw0QteH1gBSwF3elf/8GAew2Uh/0S7HsU1iGtjhlFy80+A8nwIb3Tq6m1w==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/oxlint/-/oxlint-1.3.0.tgz",
+      "integrity": "sha512-PzAOmPxnXYpVF1q6h9pkOPH6uJ/44XrtFWJ8JcEMpoEq9HISNelD3lXhACtOAW8CArjLy/qSlu2KkyPxnXgctA==",
       "dev": true,
       "license": "MIT",
       "bin": {
@@ -7864,14 +8238,14 @@
         "url": "https://github.com/sponsors/Boshen"
       },
       "optionalDependencies": {
-        "@oxlint/darwin-arm64": "1.1.0",
-        "@oxlint/darwin-x64": "1.1.0",
-        "@oxlint/linux-arm64-gnu": "1.1.0",
-        "@oxlint/linux-arm64-musl": "1.1.0",
-        "@oxlint/linux-x64-gnu": "1.1.0",
-        "@oxlint/linux-x64-musl": "1.1.0",
-        "@oxlint/win32-arm64": "1.1.0",
-        "@oxlint/win32-x64": "1.1.0"
+        "@oxlint/darwin-arm64": "1.3.0",
+        "@oxlint/darwin-x64": "1.3.0",
+        "@oxlint/linux-arm64-gnu": "1.3.0",
+        "@oxlint/linux-arm64-musl": "1.3.0",
+        "@oxlint/linux-x64-gnu": "1.3.0",
+        "@oxlint/linux-x64-musl": "1.3.0",
+        "@oxlint/win32-arm64": "1.3.0",
+        "@oxlint/win32-x64": "1.3.0"
       }
     },
     "node_modules/p-limit": {
@@ -8127,6 +8501,22 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/prettier": {
+      "version": "3.6.1",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.6.1.tgz",
+      "integrity": "sha512-5xGWRa90Sp2+x1dQtNpIpeOQpTDBs9cZDmA/qs2vDNN2i18PdapqY7CmBeyLlMuGqXJRIOPaCaVZTLNQRWUH/A==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "prettier": "bin/prettier.cjs"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/prettier/prettier?sponsor=1"
       }
     },
     "node_modules/pretty-format": {
@@ -9191,15 +9581,15 @@
       }
     },
     "node_modules/typescript-eslint": {
-      "version": "8.34.1",
-      "resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.34.1.tgz",
-      "integrity": "sha512-XjS+b6Vg9oT1BaIUfkW3M3LvqZE++rbzAMEHuccCfO/YkP43ha6w3jTEMilQxMF92nVOYCcdjv1ZUhAa1D/0ow==",
+      "version": "8.35.0",
+      "resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.35.0.tgz",
+      "integrity": "sha512-uEnz70b7kBz6eg/j0Czy6K5NivaYopgxRjsnAJ2Fx5oTLo3wefTHIbL7AkQr1+7tJCRVpTs/wiM8JR/11Loq9A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/eslint-plugin": "8.34.1",
-        "@typescript-eslint/parser": "8.34.1",
-        "@typescript-eslint/utils": "8.34.1"
+        "@typescript-eslint/eslint-plugin": "8.35.0",
+        "@typescript-eslint/parser": "8.35.0",
+        "@typescript-eslint/utils": "8.35.0"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -9636,6 +10026,7 @@
       },
       "peerDependencies": {
         "@cellix/api-services-spec": "^1.0.0",
+        "@cellix/data-sources-mongoose": "^1.0.0",
         "@ocom/api-context-spec": "^1.0.0",
         "@ocom/api-graphql": "^1.0.0",
         "@ocom/api-persistence": "^1.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -9628,6 +9628,8 @@
         "@types/node": "^18.19.70",
         "azure-functions-core-tools": "^4.x",
         "eslint": "^9.29.0",
+        "eslint-plugin-oxlint": "^1.1.0",
+        "oxlint": "^1.1.0",
         "rimraf": "^6.0.1",
         "typescript": "^5.8.3",
         "typescript-eslint": "^8.34.0"
@@ -9649,6 +9651,8 @@
       "devDependencies": {
         "@eslint/js": "^9.29.0",
         "eslint": "^9.29.0",
+        "eslint-plugin-oxlint": "^1.1.0",
+        "oxlint": "^1.1.0",
         "rimraf": "^6.0.1",
         "typescript": "^5.8.3",
         "typescript-eslint": "^8.34.0"
@@ -9664,6 +9668,8 @@
       "devDependencies": {
         "@eslint/js": "^9.29.0",
         "eslint": "^9.29.0",
+        "eslint-plugin-oxlint": "^1.1.0",
+        "oxlint": "^1.1.0",
         "rimraf": "^6.0.1",
         "typescript": "^5.8.3",
         "typescript-eslint": "^8.34.0"
@@ -9684,7 +9690,9 @@
         "@types/jest": "^29.5.14",
         "eslint": "^9.29.0",
         "eslint-plugin-jest": "^28.13.5",
+        "eslint-plugin-oxlint": "^1.1.0",
         "jest": "^29.7.0",
+        "oxlint": "^1.1.0",
         "rimraf": "^6.0.1",
         "typescript": "^5.8.3",
         "typescript-eslint": "^8.34.0"
@@ -9708,7 +9716,9 @@
         "@eslint/js": "^9.29.0",
         "@types/jest": "^29.5.14",
         "eslint": "^9.29.0",
+        "eslint-plugin-oxlint": "^1.1.0",
         "jest": "^29.7.0",
+        "oxlint": "^1.1.0",
         "rimraf": "^6.0.1",
         "typescript": "^5.8.3",
         "typescript-eslint": "^8.34.0"
@@ -9725,7 +9735,9 @@
         "@eslint/js": "^9.29.0",
         "@types/jest": "^29.5.14",
         "eslint": "^9.29.0",
+        "eslint-plugin-oxlint": "^1.1.0",
         "jest": "^29.7.0",
+        "oxlint": "^1.1.0",
         "rimraf": "^6.0.1",
         "typescript": "^5.8.3",
         "typescript-eslint": "^8.34.0"
@@ -9750,6 +9762,8 @@
       "devDependencies": {
         "@eslint/js": "^9.29.0",
         "eslint": "^9.29.0",
+        "eslint-plugin-oxlint": "^1.1.0",
+        "oxlint": "^1.1.0",
         "typescript-eslint": "^8.34.0"
       },
       "peerDependencies": {
@@ -9776,6 +9790,8 @@
       "devDependencies": {
         "@eslint/js": "^9.29.0",
         "eslint": "^9.29.0",
+        "eslint-plugin-oxlint": "^1.1.0",
+        "oxlint": "^1.1.0",
         "rimraf": "^6.0.1",
         "typescript": "^5.8.3",
         "typescript-eslint": "^8.34.0"
@@ -9791,6 +9807,8 @@
       "devDependencies": {
         "@eslint/js": "^9.29.0",
         "eslint": "^9.29.0",
+        "eslint-plugin-oxlint": "^1.1.0",
+        "oxlint": "^1.1.0",
         "rimraf": "^6.0.1",
         "typescript": "^5.8.3",
         "typescript-eslint": "^8.34.0"
@@ -9824,6 +9842,8 @@
       "devDependencies": {
         "@eslint/js": "^9.29.0",
         "eslint": "^9.29.0",
+        "eslint-plugin-oxlint": "^1.1.0",
+        "oxlint": "^1.1.0",
         "rimraf": "^6.0.1",
         "typescript": "^5.8.3",
         "typescript-eslint": "^8.34.0"
@@ -9842,6 +9862,8 @@
       "devDependencies": {
         "@eslint/js": "^9.29.0",
         "eslint": "^9.29.0",
+        "eslint-plugin-oxlint": "^1.1.0",
+        "oxlint": "^1.1.0",
         "rimraf": "^6.0.1",
         "typescript": "^5.8.3",
         "typescript-eslint": "^8.34.0"
@@ -9867,6 +9889,8 @@
       "devDependencies": {
         "@eslint/js": "^9.29.0",
         "eslint": "^9.29.0",
+        "eslint-plugin-oxlint": "^1.1.0",
+        "oxlint": "^1.1.0",
         "rimraf": "^6.0.1",
         "typescript": "^5.8.3",
         "typescript-eslint": "^8.34.0"

--- a/package.json
+++ b/package.json
@@ -9,6 +9,8 @@
     "start": "npm run build && concurrently npm:start:* --kill-others-on-fail",
     "build": "npm run build --ws --if-present",
     "lint": "npm run lint --ws --if-present",
+    "format": "npm run format --ws --if-present",
+    "format:fix": "npm run format:fix --ws --if-present",
     "tsbuild": "tsc --build",
     "tswatch": "tsc --build --watch",
     "clean": "npm install && npm run clean --ws --if-present && rimraf dist node_modules package-lock.json",
@@ -31,7 +33,9 @@
     "packages/api"
   ],
   "devDependencies": {
+    "@prettier/plugin-oxc": "^0.0.4",
     "concurrently": "^9.1.2",
+    "prettier": "^3.6.1",
     "rimraf": "^6.0.1",
     "typescript": "^5.8.3"
   }

--- a/packages/api-context-spec/.prettierrc.json
+++ b/packages/api-context-spec/.prettierrc.json
@@ -1,7 +1,0 @@
-{
-    "tabWidth": 2,
-    "useTabs": false,
-    "jsxSingleQuote": false,
-    "singleQuote": false,
-    "printWidth": 150
-}

--- a/packages/api-context-spec/package.json
+++ b/packages/api-context-spec/package.json
@@ -8,6 +8,7 @@
   "main": "dist/src/index.js",
   "types": "dist/src/index.d.ts",
   "scripts": {
+    "prebuild": "npm run lint",
     "build": "tsc --build",
     "clean": "rimraf dist node_modules tsconfig.tsbuildinfo && tsc --build --clean",
     "lint": "oxlint --max-warnings=0 && eslint --max-warnings=0"

--- a/packages/api-context-spec/package.json
+++ b/packages/api-context-spec/package.json
@@ -11,7 +11,9 @@
     "prebuild": "npm run lint",
     "build": "tsc --build",
     "clean": "rimraf dist node_modules tsconfig.tsbuildinfo && tsc --build --clean",
-    "lint": "oxlint --max-warnings=0 && eslint --max-warnings=0"
+    "lint": "oxlint --max-warnings=0 && eslint --max-warnings=0",
+    "format": "prettier --check \"src/**/*.ts\" --experimental-cli",
+    "format:fix": "prettier --write \"src/**/*.ts\""
   },
   "peerDependencies": {
     "@ocom/api-domain": "^1.0.0"

--- a/packages/api-context-spec/package.json
+++ b/packages/api-context-spec/package.json
@@ -10,7 +10,7 @@
   "scripts": {
     "build": "tsc --build",
     "clean": "rimraf dist node_modules tsconfig.tsbuildinfo && tsc --build --clean",
-    "lint": "eslint --max-warnings=0"
+    "lint": "oxlint --max-warnings=0 && eslint --max-warnings=0"
   },
   "peerDependencies": {
     "@ocom/api-domain": "^1.0.0"
@@ -20,6 +20,8 @@
     "typescript": "^5.8.3",
     "eslint": "^9.29.0",
     "@eslint/js": "^9.29.0",
-    "typescript-eslint": "^8.34.0"
+    "typescript-eslint": "^8.34.0",
+    "eslint-plugin-oxlint": "^1.1.0",
+    "oxlint": "^1.1.0"
   }
 }

--- a/packages/api-data-sources-mongoose-models/package.json
+++ b/packages/api-data-sources-mongoose-models/package.json
@@ -11,7 +11,9 @@
     "prebuild": "npm run lint",
     "build": "tsc --build",
     "clean": "rimraf dist node_modules tsconfig.buildinfo && tsc --build --clean",
-    "lint": "oxlint --max-warnings=0 && eslint --max-warnings=0"
+    "lint": "oxlint --max-warnings=0 && eslint --max-warnings=0",
+    "format": "prettier --check \"src/**/*.ts\" --experimental-cli",
+    "format:fix": "prettier --write \"src/**/*.ts\""
   },
   "peerDependencies": {
     "@cellix/data-sources-mongoose": "^1.0.0"

--- a/packages/api-data-sources-mongoose-models/package.json
+++ b/packages/api-data-sources-mongoose-models/package.json
@@ -10,7 +10,7 @@
   "scripts": {
     "build": "tsc --build",
     "clean": "rimraf dist node_modules tsconfig.buildinfo && tsc --build --clean",
-    "lint": "eslint --max-warnings=0"
+    "lint": "oxlint --max-warnings=0 && eslint --max-warnings=0"
   },
   "peerDependencies": {
     "@cellix/data-sources-mongoose": "^1.0.0"
@@ -20,6 +20,8 @@
     "typescript": "^5.8.3",
     "eslint": "^9.29.0",
     "@eslint/js": "^9.29.0",
-    "typescript-eslint": "^8.34.0"
+    "typescript-eslint": "^8.34.0",
+    "eslint-plugin-oxlint": "^1.1.0",
+    "oxlint": "^1.1.0"
   }
 }

--- a/packages/api-data-sources-mongoose-models/package.json
+++ b/packages/api-data-sources-mongoose-models/package.json
@@ -8,6 +8,7 @@
   "main": "dist/src/index.js",
   "types": "dist/src/index.d.ts",
   "scripts": {
+    "prebuild": "npm run lint",
     "build": "tsc --build",
     "clean": "rimraf dist node_modules tsconfig.buildinfo && tsc --build --clean",
     "lint": "oxlint --max-warnings=0 && eslint --max-warnings=0"

--- a/packages/api-domain/eslint.config.mjs
+++ b/packages/api-domain/eslint.config.mjs
@@ -4,10 +4,4 @@ import jestConfig from '../../eslint.jest.config.mjs';
 export default [
   ...baseConfig,
   jestConfig,
-  {
-    files: ['./src/domain/contexts/**/*.ts'],
-    rules: {
-      '@typescript-eslint/no-empty-object-type': 'off',
-    },
-  },
 ];

--- a/packages/api-domain/package.json
+++ b/packages/api-domain/package.json
@@ -12,6 +12,8 @@
     "build": "tsc --build",
     "clean": "rimraf dist node_modules tsconfig.tsbuildinfo && tsc --build --clean",
     "lint": "oxlint --max-warnings=0 && eslint --max-warnings=0",
+    "format": "prettier --check \"src/**/*.ts\" --experimental-cli",
+    "format:fix": "prettier --write \"src/**/*.ts\"",
     "test": "npx jest --watchAll=true"
   },
   "peerDependencies": {

--- a/packages/api-domain/package.json
+++ b/packages/api-domain/package.json
@@ -8,6 +8,7 @@
   "main": "dist/src/index.js",
   "types": "dist/src/index.d.ts",
   "scripts": {
+    "prebuild": "npm run lint",
     "build": "tsc --build",
     "clean": "rimraf dist node_modules tsconfig.tsbuildinfo && tsc --build --clean",
     "lint": "oxlint --max-warnings=0 && eslint --max-warnings=0",

--- a/packages/api-domain/package.json
+++ b/packages/api-domain/package.json
@@ -10,7 +10,7 @@
   "scripts": {
     "build": "tsc --build",
     "clean": "rimraf dist node_modules tsconfig.tsbuildinfo && tsc --build --clean",
-    "lint": "eslint --max-warnings=0",
+    "lint": "oxlint --max-warnings=0 && eslint --max-warnings=0",
     "test": "npx jest --watchAll=true"
   },
   "peerDependencies": {
@@ -28,6 +28,8 @@
     "jest": "^29.7.0",
     "rimraf": "^6.0.1",
     "typescript": "^5.8.3",
-    "typescript-eslint": "^8.34.0"
+    "typescript-eslint": "^8.34.0",
+    "eslint-plugin-oxlint": "^1.1.0",
+    "oxlint": "^1.1.0"
   }
 }

--- a/packages/api-domain/readme.md
+++ b/packages/api-domain/readme.md
@@ -11,7 +11,7 @@ Recipe:
 nvm use v20
 
 npm i -D jest @types/jest -w api-domain
-npm i -D eslint @eslint/js typescript-eslint -w @ocom/api-domain
+npm i -D eslint @eslint/js typescript-eslint oxlint eslint-plugin-oxlint -w @ocom/api-domain
 npx jest --init -w api-domain
 (choose node)
 

--- a/packages/api-domain/src/domain/contexts/case/violation/violation.permissions.ts
+++ b/packages/api-domain/src/domain/contexts/case/violation/violation.permissions.ts
@@ -1,0 +1,1 @@
+export interface ViolationPermissions {}

--- a/packages/api-domain/src/domain/contexts/user/staff-role/staff-role-property-permissions.ts
+++ b/packages/api-domain/src/domain/contexts/user/staff-role/staff-role-property-permissions.ts
@@ -14,8 +14,6 @@ export interface StaffRolePropertyPermissionsEntityReference extends Readonly<St
 
 export class StaffRolePropertyPermissions extends DomainSeedwork.ValueObject<StaffRolePropertyPermissionsProps> implements StaffRolePropertyPermissionsEntityReference {
   // private readonly visa: UserVisa;
-  // [NN] [ESLINT] temporarily disabled ESLint rule for unused vars
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
   constructor(props: StaffRolePropertyPermissionsProps, _visa: UserVisa) {
     super(props);
     // this.visa = visa;

--- a/packages/api-domain/src/domain/contexts/user/staff-role/staff-role-service-permissions.ts
+++ b/packages/api-domain/src/domain/contexts/user/staff-role/staff-role-service-permissions.ts
@@ -12,8 +12,6 @@ export interface StaffRoleServicePermissionsEntityReference extends Readonly<Sta
 
 export class StaffRoleServicePermissions extends DomainSeedwork.ValueObject<StaffRoleServicePermissionsProps> implements StaffRoleServicePermissionsEntityReference {
   // private readonly visa: UserVisa;
-  // [NN] [ESLINT] temporarily disabled ESLint rule for unused vars
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
   constructor(props: StaffRoleServicePermissionsProps, _visa: UserVisa) {
     super(props);
     // this.visa = visa;

--- a/packages/api-domain/src/domain/contexts/user/staff-role/staff-role-service-ticket-permissions.ts
+++ b/packages/api-domain/src/domain/contexts/user/staff-role/staff-role-service-ticket-permissions.ts
@@ -16,8 +16,6 @@ export interface StaffRoleServiceTicketPermissionsEntityReference extends Readon
 
 export class StaffRoleServiceTicketPermissions extends DomainSeedwork.ValueObject<StaffRoleServiceTicketPermissionsProps> implements StaffRoleServiceTicketPermissionsEntityReference {
   // private readonly visa: UserVisa;
-  // [NN] [ESLINT] temporarily disabled ESLint rule for unused vars
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
   constructor(props: StaffRoleServiceTicketPermissionsProps, _visa: UserVisa) {
     super(props);
     // this.visa = visa;

--- a/packages/api-domain/src/domain/contexts/user/staff-role/staff-role-violation-ticket-permissions.ts
+++ b/packages/api-domain/src/domain/contexts/user/staff-role/staff-role-violation-ticket-permissions.ts
@@ -16,8 +16,6 @@ export interface StaffRoleViolationTicketPermissionsEntityReference extends Read
 
 export class StaffRoleViolationTicketPermissions extends DomainSeedwork.ValueObject<StaffRoleViolationTicketPermissionsProps> implements StaffRoleViolationTicketPermissionsEntityReference {
   // private readonly visa: UserVisa;
-  // [NN] [ESLINT] temporarily disabled ESLint rule for unused vars
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
   constructor(props: StaffRoleViolationTicketPermissionsProps, _visa: UserVisa) {
     super(props);
     // this.visa = visa;

--- a/packages/api-domain/src/domain/contexts/user/vendor-user/vendor-user-contact-information.ts
+++ b/packages/api-domain/src/domain/contexts/user/vendor-user/vendor-user-contact-information.ts
@@ -8,8 +8,6 @@ export interface VendorUserContactInformationProps extends DomainSeedwork.ValueO
 export interface VendorUserContactInformationEntityReference extends Readonly<VendorUserContactInformationProps> {}
 
 export class VendorUserContactInformation extends DomainSeedwork.ValueObject<VendorUserContactInformationProps> implements VendorUserContactInformationEntityReference {
-  // [NN] [ESLINT] temporarily disabled ESLint rule for useless constructor
-  // eslint-disable-next-line @typescript-eslint/no-useless-constructor
   constructor(props: VendorUserContactInformationProps) {
     super(props);
   }

--- a/packages/api-domain/src/domain/contexts/user/vendor-user/vendor-user-identity-details.ts
+++ b/packages/api-domain/src/domain/contexts/user/vendor-user/vendor-user-identity-details.ts
@@ -10,8 +10,6 @@ export interface VendorUserIdentityDetailsProps extends DomainSeedwork.ValueObje
 export interface VendorUserIdentityDetailsEntityReference extends Readonly<VendorUserIdentityDetailsProps> {}
 
 export class VendorUserIdentityDetails extends DomainSeedwork.ValueObject<VendorUserIdentityDetailsProps> implements VendorUserIdentityDetailsEntityReference {
-  // [NN] [ESLINT] temporarily disabled ESLint rule for useless constructor
-  // eslint-disable-next-line @typescript-eslint/no-useless-constructor
   constructor(props: VendorUserIdentityDetailsProps) {
     super(props);
   }

--- a/packages/api-domain/src/domain/contexts/user/vendor-user/vendor-user-personal-information.ts
+++ b/packages/api-domain/src/domain/contexts/user/vendor-user/vendor-user-personal-information.ts
@@ -13,8 +13,6 @@ export interface VendorUserPersonalInformationEntityReference extends Readonly<O
 }
 
 export class VendorUserPersonalInformation extends DomainSeedwork.ValueObject<VendorUserPersonalInformationProps> implements VendorUserPersonalInformationEntityReference{
-  // [NN] [ESLINT] temporarily disabled ESLint rule for useless constructor
-  // eslint-disable-next-line @typescript-eslint/no-useless-constructor
   constructor(props: VendorUserPersonalInformationProps) {
     super(props);
   }

--- a/packages/api-domain/src/domain/iam/member/contexts/member.case.visa.ts
+++ b/packages/api-domain/src/domain/iam/member/contexts/member.case.visa.ts
@@ -1,0 +1,1 @@
+export class MemberCaseVisa {}

--- a/packages/api-domain/src/domain/iam/member/contexts/member.property.visa.ts
+++ b/packages/api-domain/src/domain/iam/member/contexts/member.property.visa.ts
@@ -1,0 +1,1 @@
+export class MemberPropertyVisa {}

--- a/packages/api-domain/src/domain/iam/member/contexts/member.user.end-user.visa.ts
+++ b/packages/api-domain/src/domain/iam/member/contexts/member.user.end-user.visa.ts
@@ -6,8 +6,6 @@ import type { UserVisa } from '../../../contexts/user/user.visa.ts';
 export class MemberUserEndUserVisa<root extends EndUserEntityReference> implements UserVisa {
   private readonly root: root;
 
-  // [NN] [ESLINT] temporarily disabling @typescript-eslint/no-unused-vars
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
   constructor(root: root, _member: MemberEntityReference) {
     this.root = root;
   }  

--- a/packages/api-domain/src/domain/iam/member/contexts/member.user.staff-role.visa.ts
+++ b/packages/api-domain/src/domain/iam/member/contexts/member.user.staff-role.visa.ts
@@ -6,8 +6,6 @@ import type { UserVisa } from '../../../contexts/user/user.visa.ts';
 export class MemberUserStaffRoleVisa<root extends StaffRoleEntityReference> implements UserVisa {
   private readonly root: root;
 
-  // [NN] [ESLINT] temporarily disabling @typescript-eslint/no-unused-vars
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
   constructor(root: root, _member: MemberEntityReference) {
     this.root = root;
   }  

--- a/packages/api-domain/src/domain/iam/member/contexts/member.user.staff-user.visa.ts
+++ b/packages/api-domain/src/domain/iam/member/contexts/member.user.staff-user.visa.ts
@@ -6,8 +6,6 @@ import type { UserVisa } from '../../../contexts/user/user.visa.ts';
 export class MemberUserStaffUserVisa<root extends StaffUserEntityReference> implements UserVisa {
   private readonly root: root;
 
-  // [NN] [ESLINT] temporarily disabling @typescript-eslint/no-unused-vars
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
   constructor(root: root, _member: MemberEntityReference) {
     this.root = root;
   }  

--- a/packages/api-domain/src/domain/iam/member/contexts/member.user.vendor-user.visa.ts
+++ b/packages/api-domain/src/domain/iam/member/contexts/member.user.vendor-user.visa.ts
@@ -5,8 +5,6 @@ import type { VendorUserEntityReference } from '../../../contexts/user/vendor-us
 export class MemberUserEndUserVisa<root extends VendorUserEntityReference> implements UserVisa {
   private readonly root: root;
 
-  // [NN] [ESLINT] temporarily disabling @typescript-eslint/no-unused-vars
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
   constructor(root: root, _member: VendorUserEntityReference) {
     this.root = root;
   }  

--- a/packages/api-event-handler/.prettierrc.json
+++ b/packages/api-event-handler/.prettierrc.json
@@ -1,7 +1,0 @@
-{
-    "tabWidth": 2,
-    "useTabs": false,
-    "jsxSingleQuote": false,
-    "singleQuote": false,
-    "printWidth": 150
-}

--- a/packages/api-event-handler/package.json
+++ b/packages/api-event-handler/package.json
@@ -6,11 +6,13 @@
   "devDependencies": {
     "eslint": "^9.29.0",
     "@eslint/js": "^9.29.0",
-    "typescript-eslint": "^8.34.0"
+    "typescript-eslint": "^8.34.0",
+    "eslint-plugin-oxlint": "^1.1.0",
+    "oxlint": "^1.1.0"
   },
   "scripts": {
     "build": "tsc --build",
-    "lint": "eslint --max-warnings=0"
+    "lint": "oxlint --max-warnings=0 && eslint --max-warnings=0"
   },
   "author": "",
   "license": "ISC",

--- a/packages/api-event-handler/package.json
+++ b/packages/api-event-handler/package.json
@@ -11,6 +11,7 @@
     "oxlint": "^1.1.0"
   },
   "scripts": {
+    "prebuild": "npm run lint",
     "build": "tsc --build",
     "lint": "oxlint --max-warnings=0 && eslint --max-warnings=0"
   },

--- a/packages/api-event-handler/package.json
+++ b/packages/api-event-handler/package.json
@@ -13,7 +13,9 @@
   "scripts": {
     "prebuild": "npm run lint",
     "build": "tsc --build",
-    "lint": "oxlint --max-warnings=0 && eslint --max-warnings=0"
+    "lint": "oxlint --max-warnings=0 && eslint --max-warnings=0",
+    "format": "prettier --check \"src/**/*.ts\" --experimental-cli",
+    "format:fix": "prettier --write \"src/**/*.ts\""
   },
   "author": "",
   "license": "ISC",

--- a/packages/api-graphql/.prettierrc.json
+++ b/packages/api-graphql/.prettierrc.json
@@ -1,7 +1,0 @@
-{
-    "tabWidth": 2,
-    "useTabs": false,
-    "jsxSingleQuote": false,
-    "singleQuote": false,
-    "printWidth": 150
-}

--- a/packages/api-graphql/package.json
+++ b/packages/api-graphql/package.json
@@ -8,6 +8,7 @@
   "main": "dist/src/index.js",  
   "types": "dist/src/index.d.ts",
   "scripts": {
+    "prebuild": "npm run lint",
     "build": "tsc --build",
     "clean": "rimraf dist node_modules tsconfig.tsbuildinfo && tsc --build --clean",
     "lint": "oxlint --max-warnings=0 && eslint --max-warnings=0"

--- a/packages/api-graphql/package.json
+++ b/packages/api-graphql/package.json
@@ -10,7 +10,7 @@
   "scripts": {
     "build": "tsc --build",
     "clean": "rimraf dist node_modules tsconfig.tsbuildinfo && tsc --build --clean",
-    "lint": "eslint --max-warnings=0"
+    "lint": "oxlint --max-warnings=0 && eslint --max-warnings=0"
   },
   "peerDependencies": {
     "@ocom/api-context-spec": "^1.0.0"
@@ -28,6 +28,8 @@
     "typescript": "^5.8.3",
     "eslint": "^9.29.0",
     "@eslint/js": "^9.29.0",
-    "typescript-eslint": "^8.34.0"
+    "typescript-eslint": "^8.34.0",
+    "eslint-plugin-oxlint": "^1.1.0",
+    "oxlint": "^1.1.0"
   }
 }

--- a/packages/api-graphql/package.json
+++ b/packages/api-graphql/package.json
@@ -11,7 +11,9 @@
     "prebuild": "npm run lint",
     "build": "tsc --build",
     "clean": "rimraf dist node_modules tsconfig.tsbuildinfo && tsc --build --clean",
-    "lint": "oxlint --max-warnings=0 && eslint --max-warnings=0"
+    "lint": "oxlint --max-warnings=0 && eslint --max-warnings=0",
+    "format": "prettier --check \"src/**/*.ts\" --experimental-cli",
+    "format:fix": "prettier --write \"src/**/*.ts\""
   },
   "peerDependencies": {
     "@ocom/api-context-spec": "^1.0.0"

--- a/packages/api-graphql/src/azure-functions.ts
+++ b/packages/api-graphql/src/azure-functions.ts
@@ -1,15 +1,5 @@
-import {
-  ApolloServer,
-  type BaseContext,
-  type ContextFunction,
-  type HTTPGraphQLRequest,
-  HeaderMap,
-} from '@apollo/server';
-import type {
-  HttpHandler,
-  HttpRequest,
-  InvocationContext,
-} from '@azure/functions-v4';
+import { ApolloServer, type BaseContext, type ContextFunction, type HTTPGraphQLRequest, HeaderMap } from '@apollo/server';
+import type { HttpHandler, HttpRequest, InvocationContext } from '@azure/functions-v4';
 
 import type { WithRequired } from '@apollo/utils.withrequired';
 
@@ -25,10 +15,7 @@ export interface AzureFunctionsMiddlewareOptions<TContext extends BaseContext> {
 // eslint-disable-next-line @typescript-eslint/require-await
 const defaultContext: ContextFunction<[AzureFunctionsContextFunctionArgument]> = async () => ({});
 
-export function startServerAndCreateHandler(
-  server: ApolloServer,
-  options?: AzureFunctionsMiddlewareOptions<BaseContext>,
-): HttpHandler;
+export function startServerAndCreateHandler(server: ApolloServer, options?: AzureFunctionsMiddlewareOptions<BaseContext>): HttpHandler;
 export function startServerAndCreateHandler<TContext extends BaseContext>(
   server: ApolloServer<TContext>,
   options: WithRequired<AzureFunctionsMiddlewareOptions<TContext>, 'context'>,
@@ -45,7 +32,7 @@ export function startServerAndCreateHandler<TContext extends BaseContext>(
 
       const { body, headers, status } = await server.executeHTTPGraphQLRequest({
         httpGraphQLRequest: normalizedRequest,
-        context: () => contextFunction({ context, req })  as Promise<TContext>,
+        context: () => contextFunction({ context, req }) as Promise<TContext>,
       });
 
       if (body.kind === 'chunked') {
@@ -96,9 +83,7 @@ async function normalizeRequest(req: HttpRequest): Promise<HTTPGraphQLRequest> {
 }
 
 async function parseBody(req: HttpRequest): Promise<unknown> {
-  const isValidContentType = req.headers
-    .get('content-type')
-    ?.startsWith('application/json');
+  const isValidContentType = req.headers.get('content-type')?.startsWith('application/json');
   const isValidPostRequest = req.method === 'POST' && isValidContentType;
 
   if (isValidPostRequest) {

--- a/packages/api-graphql/src/context.ts
+++ b/packages/api-graphql/src/context.ts
@@ -1,3 +1,1 @@
-export class Context {
-
-}
+export class Context {}

--- a/packages/api-graphql/src/context.ts
+++ b/packages/api-graphql/src/context.ts
@@ -1,5 +1,3 @@
-// [NN} [ESLINT] Temporarily disable no extraneous class rule until Context class is fully implemented
-// eslint-disable-next-line @typescript-eslint/no-extraneous-class
 export class Context {
 
 }

--- a/packages/api-graphql/src/index.ts
+++ b/packages/api-graphql/src/index.ts
@@ -1,6 +1,6 @@
 import { ApolloServer, type BaseContext } from '@apollo/server';
 import { startServerAndCreateHandler, type AzureFunctionsMiddlewareOptions } from './azure-functions.ts';
-import { type HttpHandler  } from "@azure/functions-v4";
+import { type HttpHandler } from '@azure/functions-v4';
 import type { ApiContextSpec } from '@ocom/api-context-spec';
 
 // The GraphQL schema
@@ -17,25 +17,24 @@ interface GraphContext extends BaseContext {
 // A map of functions which return data for the schema.
 const resolvers = {
   Query: {
-    hello: (_parent:unknown,_args:unknown,context:GraphContext) => 'world' +  JSON.stringify(context.apiContext),
+    hello: (_parent: unknown, _args: unknown, context: GraphContext) => 'world' + JSON.stringify(context.apiContext),
   },
 };
 
-
-export const graphHandlerCreator = (apiContext: ApiContextSpec):HttpHandler => {
+export const graphHandlerCreator = (apiContext: ApiContextSpec): HttpHandler => {
   // Set up Apollo Server
   const server = new ApolloServer<GraphContext>({
     typeDefs,
-    resolvers
+    resolvers,
   });
-  const functionOptions : AzureFunctionsMiddlewareOptions<GraphContext> = {
+  const functionOptions: AzureFunctionsMiddlewareOptions<GraphContext> = {
     // [NN] [ESLINT] Temporarily disable require await check until Context function is fully implemented
     // eslint-disable-next-line @typescript-eslint/require-await
     context: async () => {
       return {
-        apiContext: apiContext
-      }
-    }
-  }
-  return startServerAndCreateHandler(server,functionOptions);
-}
+        apiContext: apiContext,
+      };
+    },
+  };
+  return startServerAndCreateHandler(server, functionOptions);
+};

--- a/packages/api-persistence/.prettierrc.json
+++ b/packages/api-persistence/.prettierrc.json
@@ -1,7 +1,0 @@
-{
-    "tabWidth": 2,
-    "useTabs": false,
-    "jsxSingleQuote": false,
-    "singleQuote": false,
-    "printWidth": 150
-}

--- a/packages/api-persistence/package.json
+++ b/packages/api-persistence/package.json
@@ -8,6 +8,7 @@
   "main": "dist/src/index.js",
   "types": "dist/src/index.d.ts",
   "scripts": {
+    "prebuild": "npm run lint",
     "build": "tsc --build",
     "clean": "rimraf dist node_modules tsconfig.tsbuildinfo && tsc --build --clean",
     "lint": "oxlint --max-warnings=0 && eslint --max-warnings=0"

--- a/packages/api-persistence/package.json
+++ b/packages/api-persistence/package.json
@@ -11,7 +11,9 @@
     "prebuild": "npm run lint",
     "build": "tsc --build",
     "clean": "rimraf dist node_modules tsconfig.tsbuildinfo && tsc --build --clean",
-    "lint": "oxlint --max-warnings=0 && eslint --max-warnings=0"
+    "lint": "oxlint --max-warnings=0 && eslint --max-warnings=0",
+    "format": "prettier --check \"src/**/*.ts\" --experimental-cli",
+    "format:fix": "prettier --write \"src/**/*.ts\""
   },
   "peerDependencies": {
     "@cellix/domain-seedwork": "^1.0.0",

--- a/packages/api-persistence/package.json
+++ b/packages/api-persistence/package.json
@@ -10,7 +10,7 @@
   "scripts": {
     "build": "tsc --build",
     "clean": "rimraf dist node_modules tsconfig.tsbuildinfo && tsc --build --clean",
-    "lint": "eslint --max-warnings=0"
+    "lint": "oxlint --max-warnings=0 && eslint --max-warnings=0"
   },
   "peerDependencies": {
     "@cellix/domain-seedwork": "^1.0.0",
@@ -26,6 +26,8 @@
     "typescript": "^5.8.3",
     "eslint": "^9.29.0",
     "@eslint/js": "^9.29.0",
-    "typescript-eslint": "^8.34.0"
+    "typescript-eslint": "^8.34.0",
+    "eslint-plugin-oxlint": "^1.1.0",
+    "oxlint": "^1.1.0"
   }
 }

--- a/packages/api-persistence/src/community/community/community.domain-adapter.ts
+++ b/packages/api-persistence/src/community/community/community.domain-adapter.ts
@@ -3,19 +3,21 @@ import { Models } from '@ocom/api-data-sources-mongoose-models';
 import { MongooseSeedwork } from '@cellix/data-sources-mongoose';
 import { EndUserDomainAdapter } from '../../user/end-user/end-user.domain-adapter.ts';
 
-
 export class CommunityConverter extends MongooseSeedwork.MongoTypeConverter<
-  Models.Community.Community, 
-  CommunityDomainAdapter, 
+  Models.Community.Community,
+  CommunityDomainAdapter,
   Domain.Passport,
   Domain.Contexts.Community.Community.Community<CommunityDomainAdapter>
-  > {
+> {
   constructor() {
     super(CommunityDomainAdapter, Domain.Contexts.Community.Community.Community);
   }
 }
 
-export class CommunityDomainAdapter extends MongooseSeedwork.MongooseDomainAdapter<Models.Community.Community> implements Domain.Contexts.Community.Community.CommunityProps {
+export class CommunityDomainAdapter
+  extends MongooseSeedwork.MongooseDomainAdapter<Models.Community.Community>
+  implements Domain.Contexts.Community.Community.CommunityProps
+{
   get name() {
     return this.doc.name;
   }
@@ -43,7 +45,7 @@ export class CommunityDomainAdapter extends MongooseSeedwork.MongooseDomainAdapt
   set handle(handle) {
     this.doc.handle = handle;
   }
-  
+
   get createdBy(): Domain.Contexts.User.EndUser.EndUserProps {
     if (!this.doc.createdBy) {
       throw new Error('createdBy is not populated');
@@ -61,5 +63,4 @@ export class CommunityDomainAdapter extends MongooseSeedwork.MongooseDomainAdapt
     }
     this.doc.set('createdBy', user.doc);
   }
-    
 }

--- a/packages/api-persistence/src/community/community/community.repository.ts
+++ b/packages/api-persistence/src/community/community/community.repository.ts
@@ -9,29 +9,22 @@ type PropType = CommunityDomainAdapter;
 export class CommunityRepository //<
   //PropType extends Domain.Contexts.Community.Community.CommunityProps
   //>
-  extends MongooseSeedwork.MongoRepositoryBase<
-    CommunityModelType, 
-    PropType, 
-    Domain.Passport,
-    Domain.Contexts.Community.Community.Community<PropType>
-    >
+  extends MongooseSeedwork.MongoRepositoryBase<CommunityModelType, PropType, Domain.Passport, Domain.Contexts.Community.Community.Community<PropType>>
   implements Domain.Contexts.Community.Community.CommunityRepository<PropType>
 {
-
   async getByIdWithCreatedBy(id: string): Promise<Domain.Contexts.Community.Community.Community<PropType>> {
     const mongoCommunity = await this.model.findById(id).populate('createdBy').exec();
     if (!mongoCommunity) {
       throw new Error(`Community with id ${id} not found`);
     }
-    return this.typeConverter.toDomain(mongoCommunity,this.passport);
+    return this.typeConverter.toDomain(mongoCommunity, this.passport);
   }
 
-  async getNewInstance(name: string, user: Domain.Contexts.User.EndUser.EndUserEntityReference): Promise<Domain.Contexts.Community.Community.Community<PropType>> {
+  async getNewInstance(
+    name: string,
+    user: Domain.Contexts.User.EndUser.EndUserEntityReference,
+  ): Promise<Domain.Contexts.Community.Community.Community<PropType>> {
     const adapter = this.typeConverter.toAdapter(new this.model());
-    return Promise.resolve(
-      Domain.Contexts.Community.Community.Community.getNewInstance(adapter, name, user, this.passport)
-    );
+    return Promise.resolve(Domain.Contexts.Community.Community.Community.getNewInstance(adapter, name, user, this.passport));
   }
-
 }
-  

--- a/packages/api-persistence/src/community/community/community.uow.ts
+++ b/packages/api-persistence/src/community/community/community.uow.ts
@@ -6,15 +6,14 @@ import { InProcEventBusInstance, NodeEventBusInstance } from '@cellix/event-bus-
 import { CommunityConverter } from './community.domain-adapter.ts';
 import { CommunityRepository } from './community.repository.ts';
 
-
-export const getCommunityUnitOfWork = (communityModel:Models.Community.CommunityModelType): Domain.Contexts.Community.Community.CommunityUnitOfWork => {
-
+export const getCommunityUnitOfWork = (
+  communityModel: Models.Community.CommunityModelType,
+): Domain.Contexts.Community.Community.CommunityUnitOfWork => {
   return new MongooseSeedwork.MongoUnitOfWork(
-    InProcEventBusInstance, 
+    InProcEventBusInstance,
     NodeEventBusInstance,
-    communityModel, 
-    new CommunityConverter(), 
+    communityModel,
+    new CommunityConverter(),
     CommunityRepository,
   );
-
-}
+};

--- a/packages/api-persistence/src/community/community/index.ts
+++ b/packages/api-persistence/src/community/community/index.ts
@@ -3,10 +3,9 @@ import { Models } from '@ocom/api-data-sources-mongoose-models';
 import { getCommunityUnitOfWork } from './community.uow.ts';
 
 export const CommunityPersistence = (initializedService: MongooseSeedwork.MongooseContextFactory) => {
-  const CommunityModel = Models.Community.CommunityModelFactory(initializedService)
+  const CommunityModel = Models.Community.CommunityModelFactory(initializedService);
 
   return {
     CommunityUnitOfWork: getCommunityUnitOfWork(CommunityModel),
   };
-
-}
+};

--- a/packages/api-persistence/src/community/index.ts
+++ b/packages/api-persistence/src/community/index.ts
@@ -3,7 +3,6 @@ import * as Community from './community/index.ts';
 
 export const CommunityContextPersistence = (initializedService: MongooseSeedwork.MongooseContextFactory) => {
   return {
-    Community: Community.CommunityPersistence(initializedService)
+    Community: Community.CommunityPersistence(initializedService),
   };
-
-}
+};

--- a/packages/api-persistence/src/index.ts
+++ b/packages/api-persistence/src/index.ts
@@ -1,9 +1,7 @@
-import { MongooseSeedwork }  from '@cellix/data-sources-mongoose';
+import { MongooseSeedwork } from '@cellix/data-sources-mongoose';
 import * as Community from './community/index.ts';
 import * as User from './user/index.ts';
 import type { DomainDataSource } from '@ocom/api-domain';
-
-
 
 export const Persistence = (initializedService: MongooseSeedwork.MongooseContextFactory): DomainDataSource => {
   // [NN] [ESLINT] disabling the ESLint rule here to ensure that the initializedService is checked for null or undefined
@@ -12,9 +10,9 @@ export const Persistence = (initializedService: MongooseSeedwork.MongooseContext
     throw new Error('MongooseSeedwork.MongooseContextFactory is required');
   }
 
-  const dataSource:DomainDataSource = {
+  const dataSource: DomainDataSource = {
     Community: Community.CommunityContextPersistence(initializedService),
     User: User.UserContextPersistence(initializedService),
-  } ;
+  };
   return dataSource;
 };

--- a/packages/api-persistence/src/user/end-user/end-user.domain-adapter.ts
+++ b/packages/api-persistence/src/user/end-user/end-user.domain-adapter.ts
@@ -2,26 +2,26 @@ import { Domain } from '@ocom/api-domain';
 import { Models } from '@ocom/api-data-sources-mongoose-models';
 import { MongooseSeedwork } from '@cellix/data-sources-mongoose';
 
-export class EndUserConverter 
-  extends MongooseSeedwork.MongoTypeConverter<
-    Models.User.EndUser, 
-    EndUserDomainAdapter,
-    Domain.Passport,
-    Domain.Contexts.User.EndUser.EndUser<EndUserDomainAdapter>
-  > 
-{
+export class EndUserConverter extends MongooseSeedwork.MongoTypeConverter<
+  Models.User.EndUser,
+  EndUserDomainAdapter,
+  Domain.Passport,
+  Domain.Contexts.User.EndUser.EndUser<EndUserDomainAdapter>
+> {
   constructor() {
     super(EndUserDomainAdapter, Domain.Contexts.User.EndUser.EndUser<EndUserDomainAdapter>);
   }
 }
 
-export class EndUserDomainAdapter extends MongooseSeedwork.MongooseDomainAdapter<Models.User.EndUser> implements Domain.Contexts.User.EndUser.EndUserProps {
-
+export class EndUserDomainAdapter
+  extends MongooseSeedwork.MongooseDomainAdapter<Models.User.EndUser>
+  implements Domain.Contexts.User.EndUser.EndUserProps
+{
   get userType() {
     return this.doc.userType;
   }
   set userType(userType) {
-    this.doc.userType = userType ?? "end-user";
+    this.doc.userType = userType ?? 'end-user';
   }
 
   get externalId() {
@@ -69,66 +69,66 @@ export class EndUserDomainAdapter extends MongooseSeedwork.MongooseDomainAdapter
 }
 
 export class EndUserPersonalInformationDomainAdapter implements Domain.Contexts.User.EndUser.EndUserPersonalInformationProps {
-    private readonly props: Models.User.EndUserPersonalInformation;
-    constructor(props: Models.User.EndUserPersonalInformation) {
-      this.props = props;
-    }
+  private readonly props: Models.User.EndUserPersonalInformation;
+  constructor(props: Models.User.EndUserPersonalInformation) {
+    this.props = props;
+  }
 
-    get identityDetails() {
-      // [NN] ESLINT commenting out the next line to avoid @typescript-eslint/no-unnecessary-condition
-      // if (!this.props.identityDetails) {
-      //   this.props.set('identityDetails', {});
-      // }
-      return new EndUserIdentityDetailsDomainAdapter(this.props.identityDetails);
-    }
+  get identityDetails() {
+    // [NN] ESLINT commenting out the next line to avoid @typescript-eslint/no-unnecessary-condition
+    // if (!this.props.identityDetails) {
+    //   this.props.set('identityDetails', {});
+    // }
+    return new EndUserIdentityDetailsDomainAdapter(this.props.identityDetails);
+  }
 
-    get contactInformation() {
-      // [NN] ESLINT commenting out the next line to avoid @typescript-eslint/no-unnecessary-condition
-      // if (!this.props.contactInformation) {
-      //   this.props.set('contactInformation', {});
-      // }
-      return new EndUserContactInformationDomainAdapter(this.props.contactInformation);
-    }
+  get contactInformation() {
+    // [NN] ESLINT commenting out the next line to avoid @typescript-eslint/no-unnecessary-condition
+    // if (!this.props.contactInformation) {
+    //   this.props.set('contactInformation', {});
+    // }
+    return new EndUserContactInformationDomainAdapter(this.props.contactInformation);
+  }
 }
 
 export class EndUserIdentityDetailsDomainAdapter implements Domain.Contexts.User.EndUser.EndUserIdentityDetailsProps {
-    private readonly props: Models.User.EndUserIdentityDetails;
-    constructor(props: Models.User.EndUserIdentityDetails) {
-      this.props = props;
-    }
+  private readonly props: Models.User.EndUserIdentityDetails;
+  constructor(props: Models.User.EndUserIdentityDetails) {
+    this.props = props;
+  }
 
-    get lastName() {
-      return this.props.lastName;
-    }
-    set lastName(lastName: string) {
-      this.props.lastName = lastName;
-    }
+  get lastName() {
+    return this.props.lastName;
+  }
+  set lastName(lastName: string) {
+    this.props.lastName = lastName;
+  }
 
-    get legalNameConsistsOfOneName() {
-        return this.props.legalNameConsistsOfOneName;
-    }
-    set legalNameConsistsOfOneName(legalNameConsistsOfOneName: boolean) {
-        this.props.legalNameConsistsOfOneName = legalNameConsistsOfOneName;
-    }
+  get legalNameConsistsOfOneName() {
+    return this.props.legalNameConsistsOfOneName;
+  }
+  set legalNameConsistsOfOneName(legalNameConsistsOfOneName: boolean) {
+    this.props.legalNameConsistsOfOneName = legalNameConsistsOfOneName;
+  }
 
-    get restOfName() : string | undefined {
-        return this.props.restOfName;
-    }
-    set restOfName(restOfName: string | undefined) {
-        this.props.restOfName = restOfName;
-    }
+  get restOfName(): string | undefined {
+    return this.props.restOfName;
+  }
+  set restOfName(restOfName: string | undefined) {
+    this.props.restOfName = restOfName;
+  }
 }
 
 export class EndUserContactInformationDomainAdapter implements Domain.Contexts.User.EndUser.EndUserContactInformationProps {
-    private readonly props: Models.User.EndUserContactInformation;
-    constructor(props: Models.User.EndUserContactInformation) {
-      this.props = props;
-    }
+  private readonly props: Models.User.EndUserContactInformation;
+  constructor(props: Models.User.EndUserContactInformation) {
+    this.props = props;
+  }
 
-    get email() {
-        return this.props.email;
-    }
-    set email(email: string) {
-        this.props.email = email;
-    }
+  get email() {
+    return this.props.email;
+  }
+  set email(email: string) {
+    this.props.email = email;
+  }
 }

--- a/packages/api-persistence/src/user/end-user/end-user.repository.ts
+++ b/packages/api-persistence/src/user/end-user/end-user.repository.ts
@@ -2,29 +2,26 @@ import { Domain } from '@ocom/api-domain';
 import { Models } from '@ocom/api-data-sources-mongoose-models';
 import { MongooseSeedwork } from '@cellix/data-sources-mongoose';
 
-
-export class EndUserRepository<
-  PropType extends Domain.Contexts.User.EndUser.EndUserProps
-  >
-  extends MongooseSeedwork.MongoRepositoryBase<
-    Models.User.EndUser, 
-    PropType, 
-    Domain.Passport,
-    Domain.Contexts.User.EndUser.EndUser<PropType>
-  >
-  implements  Domain.Contexts.User.EndUser.EndUserRepository<PropType>
+export class EndUserRepository<PropType extends Domain.Contexts.User.EndUser.EndUserProps>
+  extends MongooseSeedwork.MongoRepositoryBase<Models.User.EndUser, PropType, Domain.Passport, Domain.Contexts.User.EndUser.EndUser<PropType>>
+  implements Domain.Contexts.User.EndUser.EndUserRepository<PropType>
 {
   async getByExternalId(externalId: string): Promise<Domain.Contexts.User.EndUser.EndUser<PropType>> {
     const user = await this.model.findOne({ externalId: externalId }).exec();
     if (!user) {
       throw new Error(`User with externalId ${externalId} not found`);
     }
-    return this.typeConverter.toDomain(user,  this.passport);
+    return this.typeConverter.toDomain(user, this.passport);
   }
 
-  async getNewInstance(externalId: string, lastName: string, restOfName: string | undefined, email:string): Promise<Domain.Contexts.User.EndUser.EndUser<PropType>> {
+  async getNewInstance(
+    externalId: string,
+    lastName: string,
+    restOfName: string | undefined,
+    email: string,
+  ): Promise<Domain.Contexts.User.EndUser.EndUser<PropType>> {
     const adapter = this.typeConverter.toAdapter(new this.model());
-    return Promise.resolve(Domain.Contexts.User.EndUser.EndUser.getNewInstance(adapter,this.passport, externalId, lastName, restOfName, email)); //no context needed for new user
+    return Promise.resolve(Domain.Contexts.User.EndUser.EndUser.getNewInstance(adapter, this.passport, externalId, lastName, restOfName, email)); //no context needed for new user
   }
 
   async delete(id: string): Promise<void> {

--- a/packages/api-persistence/src/user/end-user/end-user.uow.ts
+++ b/packages/api-persistence/src/user/end-user/end-user.uow.ts
@@ -6,15 +6,6 @@ import { InProcEventBusInstance, NodeEventBusInstance } from '@cellix/event-bus-
 import { EndUserConverter } from './end-user.domain-adapter.ts';
 import { EndUserRepository } from './end-user.repository.ts';
 
-
-export const getEndUserUnitOfWork = (endUserModel:Models.User.EndUserModelType) : Domain.Contexts.User.EndUser.EndUserUnitOfWork  => {
-
-  return new MongooseSeedwork.MongoUnitOfWork(
-    InProcEventBusInstance, 
-    NodeEventBusInstance,
-    endUserModel, 
-    new EndUserConverter(), 
-    EndUserRepository 
-  );
-
-}
+export const getEndUserUnitOfWork = (endUserModel: Models.User.EndUserModelType): Domain.Contexts.User.EndUser.EndUserUnitOfWork => {
+  return new MongooseSeedwork.MongoUnitOfWork(InProcEventBusInstance, NodeEventBusInstance, endUserModel, new EndUserConverter(), EndUserRepository);
+};

--- a/packages/api-persistence/src/user/end-user/index.ts
+++ b/packages/api-persistence/src/user/end-user/index.ts
@@ -1,14 +1,12 @@
-import { MongooseSeedwork }  from '@cellix/data-sources-mongoose';
+import { MongooseSeedwork } from '@cellix/data-sources-mongoose';
 import { Models } from '@ocom/api-data-sources-mongoose-models';
 import { getEndUserUnitOfWork } from './end-user.uow.ts';
-
 
 export const EndUserPersistence = (initializedService: MongooseSeedwork.MongooseContextFactory) => {
   const UserModel = Models.User.UserModelFactory(initializedService);
   const EndUserModel = Models.User.EndUserModelFactory(UserModel);
 
   return {
-    EndUserUnitOfWork: getEndUserUnitOfWork(EndUserModel) ,
+    EndUserUnitOfWork: getEndUserUnitOfWork(EndUserModel),
   };
-
-}
+};

--- a/packages/api-persistence/src/user/index.ts
+++ b/packages/api-persistence/src/user/index.ts
@@ -1,10 +1,8 @@
 import { MongooseSeedwork } from '@cellix/data-sources-mongoose';
 import * as EndUser from './end-user/index.ts';
 
-
 export const UserContextPersistence = (initializedService: MongooseSeedwork.MongooseContextFactory) => {
   return {
-    EndUser: EndUser.EndUserPersistence(initializedService) 
+    EndUser: EndUser.EndUserPersistence(initializedService),
   };
-}
-
+};

--- a/packages/api-rest/.prettierrc.json
+++ b/packages/api-rest/.prettierrc.json
@@ -1,7 +1,0 @@
-{
-    "tabWidth": 2,
-    "useTabs": false,
-    "jsxSingleQuote": false,
-    "singleQuote": false,
-    "printWidth": 150
-}

--- a/packages/api-rest/package.json
+++ b/packages/api-rest/package.json
@@ -8,6 +8,7 @@
   "main": "dist/src/index.js",
   "types": "dist/src/index.d.ts",
   "scripts": {
+    "prebuild": "npm run lint",
     "build": "tsc --build",
     "clean": "rimraf dist node_modules tsconfig.tsbuildinfo && tsc --build --clean",
     "lint": "oxlint --max-warnings=0 && eslint --max-warnings=0"

--- a/packages/api-rest/package.json
+++ b/packages/api-rest/package.json
@@ -10,7 +10,7 @@
   "scripts": {
     "build": "tsc --build",
     "clean": "rimraf dist node_modules tsconfig.tsbuildinfo && tsc --build --clean",
-    "lint": "eslint --max-warnings=0"
+    "lint": "oxlint --max-warnings=0 && eslint --max-warnings=0"
   },
   "peerDependencies": {
     "@ocom/api-context-spec": "^1.0.0"
@@ -23,6 +23,8 @@
   "devDependencies": {
     "eslint": "^9.29.0",
     "@eslint/js": "^9.29.0",
-    "typescript-eslint": "^8.34.0"
+    "typescript-eslint": "^8.34.0",
+    "eslint-plugin-oxlint": "^1.1.0",
+    "oxlint": "^1.1.0"
   }
 }

--- a/packages/api-rest/package.json
+++ b/packages/api-rest/package.json
@@ -11,7 +11,9 @@
     "prebuild": "npm run lint",
     "build": "tsc --build",
     "clean": "rimraf dist node_modules tsconfig.tsbuildinfo && tsc --build --clean",
-    "lint": "oxlint --max-warnings=0 && eslint --max-warnings=0"
+    "lint": "oxlint --max-warnings=0 && eslint --max-warnings=0",
+    "format": "prettier --check \"src/**/*.ts\" --experimental-cli",
+    "format:fix": "prettier --write \"src/**/*.ts\""
   },
   "peerDependencies": {
     "@ocom/api-context-spec": "^1.0.0"

--- a/packages/api-rest/src/index.ts
+++ b/packages/api-rest/src/index.ts
@@ -8,7 +8,6 @@ export type HttpHandler = (
 ) => Promise<HttpResponseInit>; 
 
 export const restHandlerCreator = (apiContext: ApiContextSpec): HttpHandler => {
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
   return async (_request: HttpRequest, _context: InvocationContext) => { //_request: HttpRequest, _context: InvocationContext
     return Promise.resolve({
       status: 200,

--- a/packages/api/.prettierrc.json
+++ b/packages/api/.prettierrc.json
@@ -1,7 +1,0 @@
-{
-    "tabWidth": 2,
-    "useTabs": false,
-    "jsxSingleQuote": false,
-    "singleQuote": false,
-    "printWidth": 150
-}

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -8,6 +8,7 @@
   "main": "dist/src/index.js",
   "types": "dist/src/index.d.ts",
   "scripts": {
+    "prebuild": "npm run lint",
     "build": "tsc --build",
     "watch": "tsc -w",
     "clean": "rimraf dist",

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -11,7 +11,7 @@
     "build": "tsc --build",
     "watch": "tsc -w",
     "clean": "rimraf dist",
-    "lint": "eslint --max-warnings=0",
+    "lint": "oxlint --max-warnings=0 && eslint --max-warnings=0",
     "prestart": "npm run clean && npm run build",
     "start": "func start --typescript",
     "test": "echo \"No tests yet...\""
@@ -36,6 +36,8 @@
     "eslint": "^9.29.0",
     "rimraf": "^6.0.1",
     "typescript": "^5.8.3",
-    "typescript-eslint": "^8.34.0"
+    "typescript-eslint": "^8.34.0",
+    "eslint-plugin-oxlint": "^1.1.0",
+    "oxlint": "^1.1.0"
   }
 }

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -13,12 +13,15 @@
     "watch": "tsc -w",
     "clean": "rimraf dist",
     "lint": "oxlint --max-warnings=0 && eslint --max-warnings=0",
+    "format": "prettier --check \"src/**/*.ts\" --experimental-cli",
+    "format:fix": "prettier --write \"src/**/*.ts\"",
     "prestart": "npm run clean && npm run build",
     "start": "func start --typescript",
     "test": "echo \"No tests yet...\""
   },
   "peerDependencies": {
     "@cellix/api-services-spec": "^1.0.0",
+    "@cellix/data-sources-mongoose": "^1.0.0",
     "@ocom/api-context-spec": "^1.0.0",
     "@ocom/api-graphql": "^1.0.0",
     "@ocom/api-persistence": "^1.0.0",

--- a/packages/api/readme.md
+++ b/packages/api/readme.md
@@ -6,7 +6,7 @@ nvm use v20
 
 npm install -D @types/node -w api
 
-npm install -D eslint @eslint/js typescript-eslint -w @ocom/api
+npm install -D eslint @eslint/js typescript-eslint oxlint eslint-plugin-oxlint -w @ocom/api
 
 npm install @azure/identity -w api
 

--- a/packages/api/src/index.ts
+++ b/packages/api/src/index.ts
@@ -1,19 +1,17 @@
-import  './service-config/otel-starter.ts';
+import './service-config/otel-starter.ts';
 
 import { Cellix, type UninitializedServiceRegistry } from './cellix.ts';
-import type { ApiContextSpec} from '@ocom/api-context-spec';
+import type { ApiContextSpec } from '@ocom/api-context-spec';
 
 import { ServiceMongoose } from '@ocom/service-mongoose';
-import * as MongooseConfig   from "./service-config/mongoose/index.ts";
+import * as MongooseConfig from './service-config/mongoose/index.ts';
 
-import { graphHandlerCreator} from '@ocom/api-graphql';
+import { graphHandlerCreator } from '@ocom/api-graphql';
 import { restHandlerCreator } from '@ocom/api-rest';
 
-
-Cellix
-  .initializeServices<ApiContextSpec>((serviceRegistry: UninitializedServiceRegistry<ApiContextSpec>) => {
-    serviceRegistry.registerService(new ServiceMongoose(MongooseConfig.mongooseConnectionString, MongooseConfig.mongooseConnectOptions));
-  })
+Cellix.initializeServices<ApiContextSpec>((serviceRegistry: UninitializedServiceRegistry<ApiContextSpec>) => {
+  serviceRegistry.registerService(new ServiceMongoose(MongooseConfig.mongooseConnectionString, MongooseConfig.mongooseConnectOptions));
+})
   .setContext((serviceRegistry) => {
     return {
       domainDataSource: MongooseConfig.mongooseContextBuilder(serviceRegistry.getService<ServiceMongoose>(ServiceMongoose)),
@@ -22,9 +20,9 @@ Cellix
   .then((cellix) => {
     cellix
       .registerAzureFunctionHandler('graphql', { route: 'graphql' }, graphHandlerCreator)
-      .registerAzureFunctionHandler('rest', { route: 'rest' }, restHandlerCreator)
-  }).catch((error: unknown) => {
+      .registerAzureFunctionHandler('rest', { route: 'rest' }, restHandlerCreator);
+  })
+  .catch((error: unknown) => {
     console.error('Error initializing Cellix:', error);
     process.exit(1);
   });
-  

--- a/packages/api/src/service-config/mongoose/index.ts
+++ b/packages/api/src/service-config/mongoose/index.ts
@@ -4,7 +4,7 @@ import { Persistence } from '@ocom/api-persistence';
 
 const isUsingCosmosDBEmulator = process.env['NODE_ENV'] === 'development' || process.env['NODE_ENV'] === 'test';
 
-export const mongooseConnectOptions: ConnectOptions = { 
+export const mongooseConnectOptions: ConnectOptions = {
   tlsInsecure: isUsingCosmosDBEmulator, //only true for local development - required for Azure Cosmos DB emulator
   minPoolSize: 10, //default is zero
   // maxPoolSize: 100, //default is 100
@@ -12,14 +12,13 @@ export const mongooseConnectOptions: ConnectOptions = {
   autoIndex: true, //default is true - there is debate on whether this should be true or false, leaving as true for now
   autoCreate: true, //default is true - there is debate on whether this should be true or false, leaving as true for now
 
-  dbName: process.env['COSMOSDB_DBNAME'] ?? "" // need to throw an error if this is not set,
+  dbName: process.env['COSMOSDB_DBNAME'] ?? '', // need to throw an error if this is not set,
 };
 
-export const mongooseConnectionString:string = process.env["COSMOSDB_CONNECTION_STRING"] ?? ""; // need to throw an error if this is not set
+export const mongooseConnectionString: string = process.env['COSMOSDB_CONNECTION_STRING'] ?? ''; // need to throw an error if this is not set
 
-export const mongooseContextBuilder = ( initializedService :MongooseSeedwork.MongooseContextFactory ) => {
+export const mongooseContextBuilder = (initializedService: MongooseSeedwork.MongooseContextFactory) => {
   return Persistence(initializedService);
-}
-
+};
 
 export type MongooseModels = ReturnType<typeof mongooseContextBuilder>;

--- a/packages/api/src/service-config/otel-starter.ts
+++ b/packages/api/src/service-config/otel-starter.ts
@@ -1,10 +1,10 @@
 import { ServiceOtel } from '@ocom/service-otel';
 
-  const Otel = new ServiceOtel({
-    exportToConsole: process.env['NODE_ENV'] === "development",
-    useSimpleProcessors: process.env['NODE_ENV'] === "development",
-  });
-  Otel.startUp();
+const Otel = new ServiceOtel({
+  exportToConsole: process.env['NODE_ENV'] === 'development',
+  useSimpleProcessors: process.env['NODE_ENV'] === 'development',
+});
+Otel.startUp();
 
 /*
 export function initOtel():ServiceOtel {

--- a/packages/api/tsconfig.json
+++ b/packages/api/tsconfig.json
@@ -15,11 +15,12 @@
 		"src/**/*.ts"
   ],    
   "references": [  //needs to match peer dependencies in package.json
+    { "path": "../cellix-api-services-spec"},
+    { "path": "../cellix-data-sources-mongoose" },
     { "path": "../api-context-spec" },
     { "path": "../api-graphql" },
-    { "path": "../api-rest" },
     { "path": "../api-persistence" },
-    { "path": "../cellix-api-services-spec"},
+    { "path": "../api-rest" },
     { "path": "../service-mongoose" },
     { "path": "../service-otel" }
   ],

--- a/packages/cellix-api-services-spec/.prettierrc.json
+++ b/packages/cellix-api-services-spec/.prettierrc.json
@@ -1,7 +1,0 @@
-{
-    "tabWidth": 2,
-    "useTabs": false,
-    "jsxSingleQuote": false,
-    "singleQuote": false,
-    "printWidth": 150
-}

--- a/packages/cellix-api-services-spec/package.json
+++ b/packages/cellix-api-services-spec/package.json
@@ -8,6 +8,7 @@
   "main": "dist/src/index.js",
   "types": "dist/src/index.d.ts",
   "scripts": {
+    "prebuild": "npm run lint",
     "build": "tsc --build",
     "clean": "rimraf dist node_modules tsconfig.tsbuildinfo && tsc --build --clean",
     "lint": "oxlint --max-warnings=0 && eslint --max-warnings=0"

--- a/packages/cellix-api-services-spec/package.json
+++ b/packages/cellix-api-services-spec/package.json
@@ -11,7 +11,9 @@
     "prebuild": "npm run lint",
     "build": "tsc --build",
     "clean": "rimraf dist node_modules tsconfig.tsbuildinfo && tsc --build --clean",
-    "lint": "oxlint --max-warnings=0 && eslint --max-warnings=0"
+    "lint": "oxlint --max-warnings=0 && eslint --max-warnings=0",
+    "format": "prettier --check \"src/**/*.ts\" --experimental-cli",
+    "format:fix": "prettier --write \"src/**/*.ts\""
   },
   "devDependencies": {
     "rimraf": "^6.0.1",

--- a/packages/cellix-api-services-spec/package.json
+++ b/packages/cellix-api-services-spec/package.json
@@ -10,13 +10,15 @@
   "scripts": {
     "build": "tsc --build",
     "clean": "rimraf dist node_modules tsconfig.tsbuildinfo && tsc --build --clean",
-    "lint": "eslint --max-warnings=0"
+    "lint": "oxlint --max-warnings=0 && eslint --max-warnings=0"
   },
   "devDependencies": {
     "rimraf": "^6.0.1",
     "typescript": "^5.8.3",
     "eslint": "^9.29.0",
     "@eslint/js": "^9.29.0",
-    "typescript-eslint": "^8.34.0"
+    "typescript-eslint": "^8.34.0",
+    "eslint-plugin-oxlint": "^1.1.0",
+    "oxlint": "^1.1.0"
   }
 }

--- a/packages/cellix-api-services-spec/readme.md
+++ b/packages/cellix-api-services-spec/readme.md
@@ -1,1 +1,2 @@
 npm i -D -w api-services-spec @tsconfig/node20 @tsconfig/node-ts typescript
+npm i -D -w api-services-spec eslint @eslint/js typescript-eslint oxlint eslint-plugin-oxlint

--- a/packages/cellix-data-sources-mongoose/package.json
+++ b/packages/cellix-data-sources-mongoose/package.json
@@ -8,6 +8,7 @@
   "main": "dist/src/index.js",
   "types": "dist/src/index.d.ts",
   "scripts": {
+    "prebuild": "npm run lint",
     "build": "tsc --build",
     "clean": "rimraf dist node_modules tsconfig.tsbuildinfo && tsc --build --clean",
     "lint": "oxlint --max-warnings=0 && eslint --max-warnings=0"

--- a/packages/cellix-data-sources-mongoose/package.json
+++ b/packages/cellix-data-sources-mongoose/package.json
@@ -10,7 +10,7 @@
   "scripts": {
     "build": "tsc --build",
     "clean": "rimraf dist node_modules tsconfig.tsbuildinfo && tsc --build --clean",
-    "lint": "eslint --max-warnings=0"
+    "lint": "oxlint --max-warnings=0 && eslint --max-warnings=0"
   },
   "peerDependencies": {
     "@cellix/domain-seedwork": "^1.0.0"
@@ -20,7 +20,9 @@
     "typescript": "^5.8.3",
     "eslint": "^9.29.0",
     "@eslint/js": "^9.29.0",
-    "typescript-eslint": "^8.34.0"
+    "typescript-eslint": "^8.34.0",
+    "eslint-plugin-oxlint": "^1.1.0",
+    "oxlint": "^1.1.0"
   },
   "dependencies": {
     "@types/mongoose": "^5.11.96"

--- a/packages/cellix-data-sources-mongoose/package.json
+++ b/packages/cellix-data-sources-mongoose/package.json
@@ -11,7 +11,9 @@
     "prebuild": "npm run lint",
     "build": "tsc --build",
     "clean": "rimraf dist node_modules tsconfig.tsbuildinfo && tsc --build --clean",
-    "lint": "oxlint --max-warnings=0 && eslint --max-warnings=0"
+    "lint": "oxlint --max-warnings=0 && eslint --max-warnings=0",
+    "format": "prettier --check \"src/**/*.ts\" --experimental-cli",
+    "format:fix": "prettier --write \"src/**/*.ts\""
   },
   "peerDependencies": {
     "@cellix/domain-seedwork": "^1.0.0"

--- a/packages/cellix-data-sources-mongoose/readme.md
+++ b/packages/cellix-data-sources-mongoose/readme.md
@@ -1,2 +1,2 @@
 npm i -D -w cellix-data-sources-mongoose @tsconfig/node20 @tsconfig/node-ts typescript
-npm i -D -w cellix-data-sources-mongoose eslint @eslint/js typescript-eslint
+npm i -D -w cellix-data-sources-mongoose eslint @eslint/js typescript-eslint oxlint eslint-plugin-oxlint

--- a/packages/cellix-data-sources-mongoose/src/mongoose-seedwork/base.ts
+++ b/packages/cellix-data-sources-mongoose/src/mongoose-seedwork/base.ts
@@ -35,8 +35,6 @@ export const SubdocumentBaseOptions: SchemaOptions = BaseOptions;
  * This should NOT be used for defining array elements, as they will be automatically converted to Subdocuments
  * While defining the Mongoose Schema, NestedPath object should be defined inline with the parent schema
  */
-// [NN] [ESLINT] disabling @typrscrip-eslint/no-empty-object-type
-// eslint-disable-next-line @typescript-eslint/no-empty-object-type
 export interface NestedPath extends Document {}
 export const NestedPathOptions : SchemaOptions = {
   _id: false,

--- a/packages/cellix-domain-seedwork/.prettierrc.json
+++ b/packages/cellix-domain-seedwork/.prettierrc.json
@@ -1,7 +1,0 @@
-{
-    "tabWidth": 2,
-    "useTabs": false,
-    "jsxSingleQuote": false,
-    "singleQuote": false,
-    "printWidth": 150
-}

--- a/packages/cellix-domain-seedwork/eslint.config.mjs
+++ b/packages/cellix-domain-seedwork/eslint.config.mjs
@@ -1,6 +1,9 @@
 import baseConfig from '../../eslint.config.mjs';
 import tseslint from 'typescript-eslint';
+import oxlint from 'eslint-plugin-oxlint';
 
 export default tseslint.config(
-  ...baseConfig
+  ...baseConfig,
+  ...oxlint.configs['flat/recommended'],
+  ...oxlint.configs['flat/typescript'],
 );

--- a/packages/cellix-domain-seedwork/package.json
+++ b/packages/cellix-domain-seedwork/package.json
@@ -10,13 +10,15 @@
   "scripts": {
     "build": "tsc --build",
     "clean": "rimraf dist node_modules tsconfig.tsbuildinfo && tsc --build --clean",
-    "lint": "eslint --max-warnings=0"
+    "lint": "oxlint --max-warnings=0 && eslint --max-warnings=0"
   },
   "devDependencies": {
+    "@eslint/js": "^9.29.0",
+    "eslint": "^9.29.0",
+    "eslint-plugin-oxlint": "^1.1.0",
+    "oxlint": "^1.1.0",
     "rimraf": "^6.0.1",
     "typescript": "^5.8.3",
-    "eslint": "^9.29.0",
-    "@eslint/js": "^9.29.0",
     "typescript-eslint": "^8.34.0"
   }
 }

--- a/packages/cellix-domain-seedwork/package.json
+++ b/packages/cellix-domain-seedwork/package.json
@@ -8,9 +8,12 @@
   "main": "dist/src/index.js",
   "types": "dist/src/index.d.ts",
   "scripts": {
+    "prebuild": "npm run lint",
     "build": "tsc --build",
     "clean": "rimraf dist node_modules tsconfig.tsbuildinfo && tsc --build --clean",
-    "lint": "oxlint --max-warnings=0 && eslint --max-warnings=0"
+    "lint": "oxlint --max-warnings=0 && eslint --max-warnings=0",
+    "format": "prettier --check \"src/**/*.ts\" --experimental-cli",
+    "format:fix": "prettier --write \"src/**/*.ts\""
   },
   "devDependencies": {
     "@eslint/js": "^9.29.0",

--- a/packages/cellix-domain-seedwork/readme.md
+++ b/packages/cellix-domain-seedwork/readme.md
@@ -3,3 +3,5 @@ npm i -D -w cellix-domain-seedwork @tsconfig/node20 @tsconfig/node-ts typescript
 npm i -D -w cellix-domain-seedwork rimraf
 
 npm i -D -w cellix-domain-seedwork eslint @eslint/js typescript-eslint
+
+npm i -D -w @cellix/domain-seedwork oxlint eslint-plugin-oxlint

--- a/packages/cellix-domain-seedwork/src/domain-seedwork/aggregate-root.ts
+++ b/packages/cellix-domain-seedwork/src/domain-seedwork/aggregate-root.ts
@@ -51,8 +51,6 @@ export class AggregateRoot<PropType extends DomainEntityProps, PassportType> ext
   public getIntegrationEvents(): ReadonlyArray<CustomDomainEvent<unknown>> {
     return this.integrationEvents;
   }
-  // [NN] [ESLINT] disabling @typescript-eslint/no-unused-vars for default onSave method
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
   public onSave(_isModified: boolean): void {
     //override this method to do something on save
   }

--- a/packages/cellix-domain-seedwork/src/domain-seedwork/base-domain-execution-context.ts
+++ b/packages/cellix-domain-seedwork/src/domain-seedwork/base-domain-execution-context.ts
@@ -1,3 +1,1 @@
-// [NN] [ESLINT] disabling @typescript/eslint/no-empty-object-type
-// eslint-disable-next-line @typescript-eslint/no-empty-object-type
 export interface BaseDomainExecutionContext {}

--- a/packages/cellix-domain-seedwork/src/domain-seedwork/value-object.ts
+++ b/packages/cellix-domain-seedwork/src/domain-seedwork/value-object.ts
@@ -1,5 +1,3 @@
-// [NN] [ESLINT] disabling @typescript/eslint/no-empty-object-type
-// eslint-disable-next-line @typescript-eslint/no-empty-object-type
 export interface ValueObjectProps {}
 
 export abstract class ValueObject<PropType extends ValueObjectProps> {

--- a/packages/cellix-event-bus-seedwork-node/.prettierrc.json
+++ b/packages/cellix-event-bus-seedwork-node/.prettierrc.json
@@ -1,7 +1,0 @@
-{
-    "tabWidth": 2,
-    "useTabs": false,
-    "jsxSingleQuote": false,
-    "singleQuote": false,
-    "printWidth": 150
-}

--- a/packages/cellix-event-bus-seedwork-node/package.json
+++ b/packages/cellix-event-bus-seedwork-node/package.json
@@ -8,6 +8,7 @@
   "main": "dist/src/index.js",
   "types": "dist/src/index.d.ts",
   "scripts": {
+    "prebuild": "npm run lint",
     "build": "tsc --build",
     "clean": "rimraf dist node_modules tsconfig.tsbuildinfo && tsc --build --clean",
     "lint": "oxlint --max-warnings=0 && eslint --max-warnings=0"

--- a/packages/cellix-event-bus-seedwork-node/package.json
+++ b/packages/cellix-event-bus-seedwork-node/package.json
@@ -11,7 +11,9 @@
     "prebuild": "npm run lint",
     "build": "tsc --build",
     "clean": "rimraf dist node_modules tsconfig.tsbuildinfo && tsc --build --clean",
-    "lint": "oxlint --max-warnings=0 && eslint --max-warnings=0"
+    "lint": "oxlint --max-warnings=0 && eslint --max-warnings=0",
+    "format": "prettier --check \"src/**/*.ts\" --experimental-cli",
+    "format:fix": "prettier --write \"src/**/*.ts\""
   },
   "devDependencies": {
     "rimraf": "^6.0.1",

--- a/packages/cellix-event-bus-seedwork-node/package.json
+++ b/packages/cellix-event-bus-seedwork-node/package.json
@@ -10,14 +10,16 @@
   "scripts": {
     "build": "tsc --build",
     "clean": "rimraf dist node_modules tsconfig.tsbuildinfo && tsc --build --clean",
-    "lint": "eslint --max-warnings=0"
+    "lint": "oxlint --max-warnings=0 && eslint --max-warnings=0"
   },
   "devDependencies": {
     "rimraf": "^6.0.1",
     "typescript": "^5.8.3",
     "eslint": "^9.29.0",
     "@eslint/js": "^9.29.0",
-    "typescript-eslint": "^8.34.0"
+    "typescript-eslint": "^8.34.0",
+    "eslint-plugin-oxlint": "^1.1.0",
+    "oxlint": "^1.1.0"
   },
   "dependencies": {
     "@opentelemetry/api": "^1.9.0",

--- a/packages/cellix-event-bus-seedwork-node/src/sync-domain-event-bus.ts
+++ b/packages/cellix-event-bus-seedwork-node/src/sync-domain-event-bus.ts
@@ -1,5 +1,3 @@
-//// Sync Domain Event
-// eslint-disable-next-line @typescript-eslint/no-empty-object-type
 export interface SyncDomainEventPayloadBaseType {}
 
 export interface SyncDomainEventType<EventPayloadType extends SyncDomainEventPayloadBaseType> {

--- a/packages/service-mongoose/.prettierrc.json
+++ b/packages/service-mongoose/.prettierrc.json
@@ -1,7 +1,0 @@
-{
-    "tabWidth": 2,
-    "useTabs": false,
-    "jsxSingleQuote": false,
-    "singleQuote": false,
-    "printWidth": 150
-}

--- a/packages/service-mongoose/package.json
+++ b/packages/service-mongoose/package.json
@@ -8,6 +8,7 @@
   "main": "dist/src/index.js",
   "types": "dist/src/index.d.ts",
   "scripts": {
+    "prebuild": "npm run lint",
     "build": "tsc --build",
     "clean": "rimraf dist node_modules tsconfig.tsbuildinfo && tsc --build --clean",
     "lint": "oxlint --max-warnings=0 && eslint --max-warnings=0"

--- a/packages/service-mongoose/package.json
+++ b/packages/service-mongoose/package.json
@@ -11,7 +11,9 @@
     "prebuild": "npm run lint",
     "build": "tsc --build",
     "clean": "rimraf dist node_modules tsconfig.tsbuildinfo && tsc --build --clean",
-    "lint": "oxlint --max-warnings=0 && eslint --max-warnings=0"
+    "lint": "oxlint --max-warnings=0 && eslint --max-warnings=0",
+    "format": "prettier --check \"src/**/*.ts\" --experimental-cli",
+    "format:fix": "prettier --write \"src/**/*.ts\""
   },
   "peerDependencies": {
     "@cellix/api-services-spec": "^1.0.0",

--- a/packages/service-mongoose/package.json
+++ b/packages/service-mongoose/package.json
@@ -10,7 +10,7 @@
   "scripts": {
     "build": "tsc --build",
     "clean": "rimraf dist node_modules tsconfig.tsbuildinfo && tsc --build --clean",
-    "lint": "eslint --max-warnings=0"
+    "lint": "oxlint --max-warnings=0 && eslint --max-warnings=0"
   },
   "peerDependencies": {
     "@cellix/api-services-spec": "^1.0.0",
@@ -24,6 +24,8 @@
     "eslint": "^9.29.0",
     "rimraf": "^6.0.1",
     "typescript": "^5.8.3",
-    "typescript-eslint": "^8.34.0"
+    "typescript-eslint": "^8.34.0",
+    "eslint-plugin-oxlint": "^1.1.0",
+    "oxlint": "^1.1.0"
   }
 }

--- a/packages/service-mongoose/readme.md
+++ b/packages/service-mongoose/readme.md
@@ -1,7 +1,7 @@
 npm install mongoose -w service-mongoose
 npm install -D typescript -w service-mongoose
 npm install -D rimraf -w service-mongoose
-npm install -D eslint @eslint/js typescript-eslint -w @ocom/service-mongoose
+npm install -D eslint @eslint/js typescript-eslint oxlint eslint-plugin-oxlint -w @ocom/service-mongoose
 
 
 

--- a/packages/service-otel/.prettierrc.json
+++ b/packages/service-otel/.prettierrc.json
@@ -1,7 +1,0 @@
-{
-    "tabWidth": 2,
-    "useTabs": false,
-    "jsxSingleQuote": false,
-    "singleQuote": false,
-    "printWidth": 150
-}

--- a/packages/service-otel/package.json
+++ b/packages/service-otel/package.json
@@ -8,6 +8,7 @@
   "main": "dist/src/index.js",
   "types": "dist/src/index.d.ts",
   "scripts": {
+    "prebuild": "npm run lint",
     "build": "tsc --build",
     "clean": "rimraf dist node_modules tsconfig.tsbuildinfo && tsc --build --clean",
     "lint": "oxlint --max-warnings=0 && eslint --max-warnings=0"

--- a/packages/service-otel/package.json
+++ b/packages/service-otel/package.json
@@ -10,7 +10,7 @@
   "scripts": {
     "build": "tsc --build",
     "clean": "rimraf dist node_modules tsconfig.tsbuildinfo && tsc --build --clean",
-    "lint": "eslint --max-warnings=0"
+    "lint": "oxlint --max-warnings=0 && eslint --max-warnings=0"
   },
   "peerDependencies": {
     "@cellix/api-services-spec": "^1.0.0"
@@ -29,6 +29,8 @@
     "eslint": "^9.29.0",
     "rimraf": "^6.0.1",
     "typescript": "^5.8.3",
-    "typescript-eslint": "^8.34.0"
+    "typescript-eslint": "^8.34.0",
+    "eslint-plugin-oxlint": "^1.1.0",
+    "oxlint": "^1.1.0"
   }
 }

--- a/packages/service-otel/package.json
+++ b/packages/service-otel/package.json
@@ -11,7 +11,9 @@
     "prebuild": "npm run lint",
     "build": "tsc --build",
     "clean": "rimraf dist node_modules tsconfig.tsbuildinfo && tsc --build --clean",
-    "lint": "oxlint --max-warnings=0 && eslint --max-warnings=0"
+    "lint": "oxlint --max-warnings=0 && eslint --max-warnings=0",
+    "format": "prettier --check \"src/**/*.ts\" --experimental-cli",
+    "format:fix": "prettier --write \"src/**/*.ts\""
   },
   "peerDependencies": {
     "@cellix/api-services-spec": "^1.0.0"

--- a/packages/service-otel/src/index.ts
+++ b/packages/service-otel/src/index.ts
@@ -9,7 +9,6 @@ import {
 import type { SyncServiceBase } from '@cellix/api-services-spec'
 import { OtelBuilder } from './otel-builder.js';
 
-// eslint-disable-next-line @typescript-eslint/no-empty-object-type
 export interface OtelContext {}
 
 export interface OtelConfig {


### PR DESCRIPTION
## Summary by Sourcery

Integrate the oxlint plugin into the monorepo’s linting setup and clean up outdated ESLint disables across packages

New Features:
- Add a new empty ViolationPermissions interface
- Introduce MemberCaseVisa and MemberPropertyVisa classes

Enhancements:
- Update all packages’ lint scripts to run oxlint before ESLint and add oxlint plus eslint-plugin-oxlint to devDependencies
- Extend root and package-level ESLint flat configs with oxlint’s recommended and TypeScript rule sets
- Remove numerous inline ESLint disable comments related to unused vars, empty-object-type, no-useless-constructor, and extraneous-class

Documentation:
- Update README files across packages to include installation instructions for oxlint and its plugin