### PR TITLE
Add prebuild script for linting and resolve linter errors

### DIFF
--- a/packages/cellix-domain-seedwork/package.json
+++ b/packages/cellix-domain-seedwork/package.json
@@ -11,7 +11,8 @@
 		"build": "tsc --build",
 		"clean": "rimraf dist node_modules tsconfig.tsbuildinfo && tsc --build --clean",
 		"lint": "biome lint",
-		"format": "biome format --write"
+		"format": "biome format --write",
+        "prebuild": "biome lint"
 	},
 	"devDependencies": {
 		"rimraf": "^6.0.1",

--- a/packages/cellix-domain-seedwork/src/domain-seedwork/aggregate-root.ts
+++ b/packages/cellix-domain-seedwork/src/domain-seedwork/aggregate-root.ts
@@ -1,5 +1,5 @@
 import { DomainEntity, type DomainEntityProps } from './domain-entity.ts';
-import { type CustomDomainEvent } from './domain-event.ts';
+import type { CustomDomainEvent } from './domain-event.ts';
 
 export interface RootEventRegistry {
 	addDomainEvent<EventProps, T extends CustomDomainEvent<EventProps>>(

--- a/packages/cellix-domain-seedwork/src/domain-seedwork/base-domain-execution-context.ts
+++ b/packages/cellix-domain-seedwork/src/domain-seedwork/base-domain-execution-context.ts
@@ -1,3 +1,2 @@
-// [NN] [ESLINT] disabling @typescript/eslint/no-empty-object-type
-// eslint-disable-next-line @typescript-eslint/no-empty-object-type
+// biome-ignore lint/suspicious/noEmptyInterface: This interface is intentionally empty to represent a base context.
 export interface BaseDomainExecutionContext {}

--- a/packages/cellix-domain-seedwork/src/domain-seedwork/domain-entity.ts
+++ b/packages/cellix-domain-seedwork/src/domain-seedwork/domain-entity.ts
@@ -1,4 +1,4 @@
-import { type Domain } from './domain.ts';
+import type { Domain } from './domain.ts';
 
 export interface DomainEntityProps {
 	readonly id: string;

--- a/packages/cellix-domain-seedwork/src/domain-seedwork/event-bus.ts
+++ b/packages/cellix-domain-seedwork/src/domain-seedwork/event-bus.ts
@@ -1,4 +1,4 @@
-import { type CustomDomainEvent, type DomainEvent } from './domain-event.ts';
+import type { CustomDomainEvent, DomainEvent } from './domain-event.ts';
 
 export interface EventBus {
 	dispatch<T extends { payload: unknown } & DomainEvent>(

--- a/packages/cellix-domain-seedwork/src/domain-seedwork/handle-event.ts
+++ b/packages/cellix-domain-seedwork/src/domain-seedwork/handle-event.ts
@@ -1,4 +1,4 @@
-import { type DomainEvent } from './domain-event.ts';
+import type { DomainEvent } from './domain-event.ts';
 
 export interface HandleEvent<T> {
 	handle(event: T): void;

--- a/packages/cellix-domain-seedwork/src/domain-seedwork/index.ts
+++ b/packages/cellix-domain-seedwork/src/domain-seedwork/index.ts
@@ -10,9 +10,9 @@ export {
 	DomainEntity,
 	PermissionError,
 } from './domain-entity.ts';
-export { type EventBus } from './event-bus.ts';
-export { type BaseDomainExecutionContext } from './base-domain-execution-context.ts';
-export { type TypeConverter } from './type-converter.ts';
-export { type PropArray } from './prop-array.ts';
-export { type UnitOfWork } from './unit-of-work.ts';
+export type { EventBus } from './event-bus.ts';
+export type { BaseDomainExecutionContext } from './base-domain-execution-context.ts';
+export type { TypeConverter } from './type-converter.ts';
+export type { PropArray } from './prop-array.ts';
+export type { UnitOfWork } from './unit-of-work.ts';
 export { ValueObject, type ValueObjectProps } from './value-object.ts';

--- a/packages/cellix-domain-seedwork/src/domain-seedwork/prop-array.ts
+++ b/packages/cellix-domain-seedwork/src/domain-seedwork/prop-array.ts
@@ -1,4 +1,4 @@
-import { type DomainEntityProps } from './domain-entity.ts';
+import type { DomainEntityProps } from './domain-entity.ts';
 
 export interface PropArray<propType extends DomainEntityProps> {
 	get items(): ReadonlyArray<propType>;

--- a/packages/cellix-domain-seedwork/src/domain-seedwork/publish-event.ts
+++ b/packages/cellix-domain-seedwork/src/domain-seedwork/publish-event.ts
@@ -1,5 +1,5 @@
 import type { DomainEvent } from './domain-event.ts';
-import { type EventBus } from './event-bus.ts';
+import type { EventBus } from './event-bus.ts';
 
 export interface PublishEvent {
 	publish<T extends { payload: unknown } & DomainEvent>(

--- a/packages/cellix-domain-seedwork/src/domain-seedwork/type-converter.ts
+++ b/packages/cellix-domain-seedwork/src/domain-seedwork/type-converter.ts
@@ -1,5 +1,5 @@
-import { type DomainEntityProps } from './domain-entity.ts';
-import { AggregateRoot } from './aggregate-root.ts';
+import type { AggregateRoot } from './aggregate-root.ts';
+import type { DomainEntityProps } from './domain-entity.ts';
 
 export interface TypeConverter<
 	PersistenceType,

--- a/packages/cellix-domain-seedwork/src/domain-seedwork/unit-of-work.ts
+++ b/packages/cellix-domain-seedwork/src/domain-seedwork/unit-of-work.ts
@@ -1,6 +1,6 @@
-import { type Repository } from './repository.ts';
-import { AggregateRoot } from './aggregate-root.ts';
-import { type DomainEntityProps } from './domain-entity.ts';
+import type { AggregateRoot } from './aggregate-root.ts';
+import type { DomainEntityProps } from './domain-entity.ts';
+import type { Repository } from './repository.ts';
 
 export interface UnitOfWork<
 	PassportType,

--- a/packages/cellix-domain-seedwork/src/domain-seedwork/value-object.ts
+++ b/packages/cellix-domain-seedwork/src/domain-seedwork/value-object.ts
@@ -1,5 +1,4 @@
-// [NN] [ESLINT] disabling @typescript/eslint/no-empty-object-type
-// eslint-disable-next-line @typescript-eslint/no-empty-object-type
+// biome-ignore lint/suspicious/noEmptyInterface: This is a base interface for value objects.
 export interface ValueObjectProps {}
 
 export abstract class ValueObject<PropType extends ValueObjectProps> {

--- a/packages/cellix-domain-seedwork/src/passport-seedwork/index.ts
+++ b/packages/cellix-domain-seedwork/src/passport-seedwork/index.ts
@@ -1,1 +1,1 @@
-export { type Visa } from './visa.ts';
+export type { Visa } from './visa.ts';


### PR DESCRIPTION
In @cellix/domain-seedwork package, Introduces a prebuild script to run linting before builds and addresses biome linter errors throughout the codebase.